### PR TITLE
認証機能の改善とバグ修正

### DIFF
--- a/back/app/controllers/api/v1/auth_controller.rb
+++ b/back/app/controllers/api/v1/auth_controller.rb
@@ -1,6 +1,13 @@
 class Api::V1::AuthController < ApplicationController
+  include ActionController::Cookies
   skip_before_action :authorize_request, only: [:google_callback]
   
+  
+  # Googleログインへのリダイレクト
+  def google
+    redirect_to '/auth/google_oauth2'
+  end
+
   # Google OAuth2コールバック処理
   def google_callback
     auth = request.env['omniauth.auth']

--- a/back/app/controllers/api/v1/sessions_controller.rb
+++ b/back/app/controllers/api/v1/sessions_controller.rb
@@ -1,7 +1,29 @@
 class Api::V1::SessionsController < ApplicationController
+  skip_before_action :authorize_request, only: [:create]
+
+  # POST /api/v1/sessions
   def create
+    user = User.find_by(email: params[:email])
+
+    if user&.authenticate(params[:session][:password])
+      token = JsonWebToken.encode(user_id: user.id)
+      render json: {
+        status: 'success',
+        message: 'ログインに成功しました。',
+        token: token,
+        user: user.as_json(only: [:id, :email, :username]) # 必要に応じてユーザー情報を返す
+      }, status: :ok
+    else
+      render json: { 
+        status: 'error', 
+        error: 'メールアドレスまたはパスワードが無効です' 
+      }, status: :unauthorized
+    end
   end
 
-  def destroy
-  end
+  # DELETE /api/v1/sessions (ログアウト処理の例)
+  # def destroy
+  #   # トークン無効化処理など (JWTはステートレスなのでクライアント側でトークンを削除するのが一般的)
+  #   render json: { message: 'ログアウトしました' }, status: :ok
+  # end
 end

--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -1,10 +1,31 @@
 class Api::V1::UsersController < ApplicationController
+  skip_before_action :authorize_request, only: [:create]
+
+
   def create
+    user = User.new(user_params)
+    if user.save
+      token = JsonWebToken.encode(user_id: user.id)
+      render json: {
+            status: 'success', # 成功ステータスを追加
+            message: 'ユーザー登録が正常に完了しました。',
+            user: user.as_json(only: [:id, :email, :username]), # パスワードダイジェストを除外
+            token: token
+          }, status: :created
+    else
+      render json: { error: user.errors.full_messages.join(', ') }, status: :unprocessable_entity
+    end
   end
 
   def show
   end
 
   def update
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:username, :email, :password, :password_confirmation)
   end
 end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -3,8 +3,9 @@ class User < ApplicationRecord
 
     has_many :oauth_providers, dependent: :destroy
 
+    validates :username, presence: true, uniqueness: { case_sensitive: false }, length: { minimum: 3, maximum: 20 }
     validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
-    validates :password, presence: true, length: { minimum: 6 }, if: :password_required?
+    validates :password, presence: true, length: { minimum: 8 }, if: :password_required? # パスワード長を8文字に変更 (フロントエンドと合わせる)
 
 
 

--- a/back/app/services/json_web_token.rb
+++ b/back/app/services/json_web_token.rb
@@ -7,10 +7,10 @@ class JsonWebToken
   end
   
   def self.decode(token)
+    raise JWT::DecodeError, "Token is nil" if token.nil? # 追加
     decoded = JWT.decode(token, SECRET_KEY)[0]
     HashWithIndifferentAccess.new decoded
-  rescue JWT::DecodeError, JWT::ExpiredSignature => e
-    # 例外処理
-    nil
+  # rescue JWT::DecodeError, JWT::ExpiredSignature => e # コントローラー側でrescueする
+  #   nil
   end
 end

--- a/back/app/services/json_web_token.rb
+++ b/back/app/services/json_web_token.rb
@@ -10,7 +10,5 @@ class JsonWebToken
     raise JWT::DecodeError, "Token is nil" if token.nil? # 追加
     decoded = JWT.decode(token, SECRET_KEY)[0]
     HashWithIndifferentAccess.new decoded
-  # rescue JWT::DecodeError, JWT::ExpiredSignature => e # コントローラー側でrescueする
-  #   nil
   end
 end

--- a/back/config/application.rb
+++ b/back/config/application.rb
@@ -6,7 +6,7 @@ require "rails/all"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module App
+module OtterBank
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.1
@@ -28,5 +28,11 @@ module App
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    # API専用モードでもセッションとクッキーを有効にする（OmniAuthに必要）
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use ActionDispatch::Session::CookieStore, key: '_otter_bank_session'
+    # config.middleware.use ActionDispatch::ContentSecurityPolicy::Middleware
+
   end
 end

--- a/back/db/migrate/20250527085848_add_username_to_users.rb
+++ b/back/db/migrate/20250527085848_add_username_to_users.rb
@@ -1,0 +1,5 @@
+class AddUsernameToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :username, :string
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_23_083526) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_27_085848) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -66,6 +66,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_23_083526) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "username"
   end
 
   add_foreign_key "achievements", "users"


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要

メールアドレスとパスワードを使用した認証方法でのログインが可能になりました。

主な変更点

- authorize_request メソッド内のトークン処理に関するバグを修正しました。
- トークンが存在しない場合、またはデコードに失敗した場合のエラーハンドリングを明確化しました。
- before_action :authorize_request の :except オプションから、存在しないアクション (google_callback) を削除し、AbstractController::ActionNotFound エラーを解消しました。
- user_params (Strong Parameters) に :username を追加し、ユーザー登録時に username を受け取れるようにしました。
- ユーザー登録成功時のレスポンスに status: 'success' とメッセージを含めるように改善しました。
- create アクション（ログイン処理）の前に authorize_request が実行されないように skip_before_action :authorize_request, only: [:create] を追加し、ログイン時の401エラーを解消しました。
- ログイン成功時・失敗時のレスポンス形式を改善し、フロントエンドで扱いやすいように status とメッセージ/エラー情報を含めるようにしました。
データベースマイグレーションの追加:
- 初期設定で作成したユーザーマイグレーションファイルで対応していないスキーマを追加しました。


- 登録成功時のフィードバック強化（より具体的なトーストメッセージ）。
- エラー発生時にもトーストでエラー内容を通知。

今後の課題
- OAuth認証ができていないままのため、実装とテスト。
- パスワードリセット機能の追加
- ゲストログインの対応
- テストケースの追加

## レビューに関して
レビューする際には、以下のprefix(接頭辞)を付けましょう。
<!-- for GitHub Copilot review rule -->
[must] → かならず変更してね  
[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)  
[nits] → ささいな指摘(nitpick) 
[ask] → 質問  
[fyi] → 参考情報
<!-- for GitHub Copilot review rule-->
## PRのルール
- まずはDraftでPRを作成する。
- レビューに出せる状態になったらOpenにする。
- レビューなしでのmainブランチへのマージは原則禁止
<!-- I want to review in Japanese. -->