### PR TITLE
ユーザーの進捗に合わせて実績の処理を実装(失敗)

### DIFF
--- a/back/app/controllers/api/v1/achievements_controller.rb
+++ b/back/app/controllers/api/v1/achievements_controller.rb
@@ -2,14 +2,63 @@ class Api::V1::AchievementsController < ApplicationController
   before_action :authorize
   
   def index
-    achievements = current_user.achievements
-    render json: achievements
-  end
+        achievements = current_user.achievements.order(:original_achievement_id) # original_achievement_id でソート
+        render json: achievements.map { |ach|
+          {
+            id: ach.id, # DB上のID
+            original_achievement_id: ach.original_achievement_id, # フロントエンドと紐づくID
+            title: ach.title,
+            description: ach.description,
+            category: ach.category,
+            unlocked: ach.unlocked,
+            progress: ach.progress,
+            image_url: ach.image_url,
+            reward: ach.reward,
+            tier: ach.tier,
+            created_at: ach.created_at,
+            updated_at: ach.updated_at
+            # 必要に応じて、進捗目標値 (progress_target) なども返す
+          }
+        }
+      end
+
+  def update
+        achievement = current_user.achievements.find_by(original_achievement_id: params[:original_achievement_id])
+
+        if achievement
+          if achievement.update(achievement_params)
+            # フロントエンドで使う主要な情報を返す
+            render json: {
+              id: achievement.id,
+              original_achievement_id: achievement.original_achievement_id,
+              title: achievement.title,
+              description: achievement.description,
+              category: achievement.category,
+              unlocked: achievement.unlocked,
+              progress: achievement.progress,
+              image_url: achievement.image_url,
+              reward: achievement.reward,
+              tier: achievement.tier
+            }, status: :ok
+          else
+            render json: { errors: achievement.errors.full_messages }, status: :unprocessable_entity
+          end
+        else
+          render json: { error: "Achievement not found" }, status: :not_found
+        end
+      end
 
   def show
     achievement = current_user.achievements.find(params[:id])
     render json: achievement
   rescue ActiveRecord::RecordNotFound
     render json: { error: '実績が見つかりません' }, status: :not_found
+  end
+
+  private
+
+  def achievement_params
+    # progress, unlocked など、更新可能なパラメータを指定
+    params.require(:achievement).permit(:progress, :unlocked)
   end
 end

--- a/back/app/controllers/api/v1/achievements_controller.rb
+++ b/back/app/controllers/api/v1/achievements_controller.rb
@@ -23,7 +23,7 @@ class Api::V1::AchievementsController < ApplicationController
       end
 
   def update
-        achievement = current_user.achievements.find_by(original_achievement_id: params[:original_achievement_id])
+        achievement = current_user.achievements.find_by(id: params[:id])
 
         if achievement
           if achievement.update(achievement_params)

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -60,8 +60,6 @@ class ApplicationController < ActionController::API
       render json: { error: "Token has expired: #{e.message}" }, status: :unauthorized
     rescue JWT::DecodeError => e
       render json: { error: "Invalid token: #{e.message}" }, status: :unauthorized
-    # `begin`に対する`end`は、`rescue`があれば省略可能だが、
-    # メソッド定義やクラス定義の`end`は必須
     end
   end
 end

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -60,6 +60,8 @@ class ApplicationController < ActionController::API
       render json: { error: "Token has expired: #{e.message}" }, status: :unauthorized
     rescue JWT::DecodeError => e
       render json: { error: "Invalid token: #{e.message}" }, status: :unauthorized
+    # `begin`に対する`end`は、`rescue`があれば省略可能だが、
+    # メソッド定義やクラス定義の`end`は必須
     end
   end
 end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -2,21 +2,13 @@ class User < ApplicationRecord
     has_secure_password validations: false # OAuth認証の場合はパスワード不要
 
     has_many :oauth_providers, dependent: :destroy
+    has_many :achievements, dependent: :destroy # ユーザーが獲得した実績
 
     validates :username, presence: true, uniqueness: { case_sensitive: false }, length: { minimum: 3, maximum: 20 }
     validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
     validates :password, presence: true, length: { minimum: 8 }, if: :password_required? # パスワード長を8文字に変更 (フロントエンドと合わせる)
 
-
-
-    # ゲストユーザーを生成または取得するクラスメソッド
-  def self.guest
-    find_or_create_by!(email: 'demo@example.com') do |user|
-      user.password = SecureRandom.urlsafe_base64
-      user.name = 'ゲストユーザー'
-      # 必要に応じて他の属性も設定
-    end
-  end
+    after_create :create_initial_achievements # ユーザー作成時に初期実績を生成
 
     # OAuthアカウントのみかどうか
   def oauth_only?
@@ -87,5 +79,61 @@ class User < ApplicationRecord
     
     # 最低3文字を保証
     username.length >= 3 ? username : "#{username}#{SecureRandom.hex(2)}"
+  end
+
+  private
+
+  def password_required
+    password_digest.present? || !password.nil?
+  end
+
+  def create_initial_achievements
+    # アプリでの実績一覧
+    # 実際のDBテーブルから読み込むとかしたいのですが、どうすればいいかわかりません。
+    # いったん、sampleAchievementsの内容を持ってくる。
+
+    defined_achievements_data = [
+      { id: 1, title: "初めての一歩", description: "初めて貯金をしました", category: "savings", imageUrl: "/placeholder.svg?height=120&width=120&text=First+Step", reward: "カワウソの基本表情", tier: 1 },
+      { id: 2, title: "千円貯金", description: "累計1,000円を貯金しました", category: "savings", imageUrl: "/placeholder.svg?height=120&width=120&text=1000+Yen", reward: "カワウソの笑顔", tier: 2 },
+      { id: 3, title: "一万円クラブ", description: "累計10,000円を貯金しました", category: "savings", imageUrl: "/placeholder.svg?height=120&width=120&text=10000+Yen", reward: "カワウソの新しい帽子", tier: 3 },
+      { id: 4, title: "貯金の達人", description: "累計30,000円を貯金しました", category: "savings", imageUrl: "/placeholder.svg?height=120&width=120&text=30000+Yen", reward: "カワウソの新しい環境", tier: 4 },
+      { id: 5, title: "十万円達成", description: "累計100,000円を貯金しました", category: "savings", imageUrl: "/placeholder.svg?height=120&width=120&text=100K+Yen", reward: "カワウソの特別な環境", tier: 5 },
+      { id: 6, title: "半分ミリオネア", description: "累計500,000円を貯金しました", category: "savings", imageUrl: "/placeholder.svg?height=120&width=120&text=500K+Yen", reward: "銀のカワウソ像", tier: 6 },
+      { id: 7, title: "ミリオネア", description: "累計1,000,000円を貯金しました", category: "savings", imageUrl: "/placeholder.svg?height=120&width=120&text=Millionaire", reward: "金のカワウソ像", tier: 7 },
+
+      # 継続は力なりシリーズ
+      { id: 50, title: "初日の決意", description: "1日連続でアプリを使用しました", category: "streak", imageUrl: "/placeholder.svg?height=120&width=120&text=Day+1", reward: "継続バッジ（初級）", tier: 1 },
+      { id: 51,  title: "一週間の慣れ", description: "7日連続でアプリを使用しました", category: "streak", imageUrl: "/placeholder.svg?height=120&width=120&text=Week+1", reward: "カワウソのカレンダー", tier:2 },
+      { id: 52, title: "10日間の継続", description: "10日連続でアプリを使用しました", category: "streak", imageUrl: "/placeholder.svg?height=120&width=120&text=10+Days", reward: "継続バッジ（中級）", tier: 3 },
+      { id: 53, title: "半月の努力", description: "15日連続でアプリを使用しました", category: "streak", imageUrl: "/placeholder.svg?height=120&width=120&text=15+Days", reward: "カワウソの特別衣装", tier: 4 },
+      { id: 54, title: "継続の達人", description: "30日連続でアプリを使用しました", category: "streak", imageUrl: "/placeholder.svg?height=120&width=120&text=30+Days", reward: "継続バッジ（金）とカワウソの王冠", tier: 5 },
+
+      # 節約の達人シリーズ
+      { id: 100, title: "節約の始まり", description: "1ヶ月の支出を前月より10%削減しました", category: "expense", imageUrl: "/placeholder.svg?height=120&width=120&text=Save+10%", reward: "節約バッジ（銅）", tier: 1},
+      { id: 101,  title: "節約の実践者",  description: "1ヶ月の支出を前月より20%削減しました",  category: "expense", imageUrl: "/placeholder.svg?height=120&width=120&text=Save+20%",  reward: "節約バッジ（銀）",  tier: 2 },
+      { id: 102,  title: "節約の達人",  description: "1ヶ月の支出を前月より30%削減しました",  category: "expense", imageUrl: "/placeholder.svg?height=120&width=120&text=Save+30%",  reward: "節約バッジ（金）",  tier: 3 },
+
+      # 特別な実績
+      { id: 150, title: "予算マスター", description: "3ヶ月連続で予算内に収まりました", category: "special", imageUrl: "/placeholder.svg?height=120&width=120&text=Budget+Master", reward: "予算管理バッジ" },
+      { id: 151, title: "投資家デビュー", description: "初めての投資を行いました", category: "special", imageUrl: "/placeholder.svg?height=120&width=120&text=Investor", reward: "投資家バッジ" },
+      { id: 152, title: "完璧な記録", description: "1ヶ月間毎日支出を記録しました", category: "special", imageUrl: "/placeholder.svg?height=120&width=120&text=Perfect+Record", reward: "記録キーパーバッジ" },
+      { id: 153, title: "目標達成者", description: "設定した貯金目標を達成しました", category: "special", imageUrl: "/placeholder.svg?height=120&width=120&text=Goal+Achiever", reward: "目標達成バッジ" },
+      { id: 154, title: "分析の達人", description: "すべての分析レポートを確認しました", category: "special", imageUrl: "/placeholder.svg?height=120&width=120&text=Analyst", reward: "分析バッジ" }
+    ]
+
+  defined_achievements_data.each do |ach_data|
+      attributes_to_create = {
+        original_achievement_id: ach_data[:id],
+        title: ach_data[:title],
+        description: ach_data[:description],
+        category: ach_data[:category].to_s,
+        image_url: ach_data[:imageUrl],
+        reward: ach_data[:reward],
+        tier: ach_data[:tier],
+        unlocked: false, # 初期状態は未解除
+        progress: 0      # 初期進捗は0
+      }
+      self.achievements.create!(attributes_to_create)
+    end
   end
 end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -1,8 +1,4 @@
 Rails.application.routes.draw do
-  # OmniAuth routes - 名前空間の外に配置
-  get '/auth/google_oauth2/callback', to: 'api/v1/auth#google_callback'
-  get '/auth/failure', to: 'api/v1/auth#auth_failure'
-  
   namespace :api do
     namespace :v1 do
       get 'likes/create_post_like'
@@ -37,7 +33,7 @@ Rails.application.routes.draw do
       get 'posts/index'
       get 'posts/show'
       get 'posts/create'
-      get 'auth/google', to: 'auth#google'
+      get 'auth/google_callback'
 
       # ユーザー関連
       resources :users, only: [:create, :update, :destroy]
@@ -55,8 +51,10 @@ Rails.application.routes.draw do
       # ゲストログイン用ルート
       post 'guest_login', to: 'guest_sessions#create'
 
-      # Auth関連 - 重複を削除
+      # Auth関連
       get 'auth/google', to: 'auth#google'
+      get 'auth/google/callback', to: 'auth#google_callback'
+
       get 'health', to: 'health#index'
     end
   end

--- a/back/db/migrate/20250603131242_add_details_to_achievements.rb
+++ b/back/db/migrate/20250603131242_add_details_to_achievements.rb
@@ -1,0 +1,9 @@
+class AddDetailsToAchievements < ActiveRecord::Migration[7.1]
+  def change
+    add_column :achievements, :original_achievement_id, :integer
+    add_column :achievements, :category, :string
+    add_column :achievements, :image_url, :string
+    add_column :achievements, :reward, :string
+    add_column :achievements, :tier, :integer
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_29_125907) do
+ActiveRecord::Schema[7.1].define(version: 2025_06_03_131242) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,11 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_29_125907) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "original_achievement_id"
+    t.string "category"
+    t.string "image_url"
+    t.string "reward"
+    t.integer "tier"
     t.index ["user_id"], name: "index_achievements_on_user_id"
   end
 

--- a/front/src/app/board/page.tsx
+++ b/front/src/app/board/page.tsx
@@ -444,14 +444,14 @@ export default function BoardPage() {
     if (!editingPost) return
 
     // エラーメッセージをリセット（編集ダイアログ用にも必要であれば同様に追加）
-    setTitleError("")
-    setContentError("")
-    setCategoryError("")
+    setEditTitleError("")
+    setEditContentError("")
+    setEditCategoryError("")
 
     let hasError = false
     // 入力検証
     if (!newPostTitle.trim()) {
-      // setTitleError("タイトルを入力してください。") // 必要であれば編集用エラーstateを別途用意
+      setEditTitleError("タイトルを入力してください。")
       toast.error("タイトルが入力されていません")
       hasError = true
     }

--- a/front/src/app/board/page.tsx
+++ b/front/src/app/board/page.tsx
@@ -220,6 +220,9 @@ export default function BoardPage() {
   const [newPostContent, setNewPostContent] = useState("")
   const [newPostCategories, setNewPostCategories] = useState<string[]>([])
   const [newCommentContent, setNewCommentContent] = useState("")
+  const [titleError, setTitleError] = useState("")
+  const [contentError, setContentError] = useState("")
+  const [categoryError, setCategoryError] = useState("")
 
   // 編集・削除対象の投稿
   const [editingPost, setEditingPost] = useState<Post | null>(null)
@@ -365,25 +368,29 @@ export default function BoardPage() {
 
   // 新規投稿の追加
   const handleAddPost = () => {
+    // エラーメッセージをリセット
+    setTitleError("")
+    setContentError("")
+    setCategoryError("")
+
+    let hasError = false
     // 入力検証
     if (!newPostTitle.trim()) {
-      toast.error("タイトルが入力されていません", {
-        description: "投稿のタイトルを入力してください。",
-      })
-      return
+      setTitleError("タイトルを入力してください。")
+      hasError = true
     }
 
     if (!newPostContent.trim()) {
-      toast.error("内容が入力されていません", {
-        description: "投稿の内容を入力してください。",
-      })
-      return
+      setContentError("内容を入力してください。")
+      hasError = true
     }
 
     if (newPostCategories.length === 0) {
-      toast.error("カテゴリーが選択されていません", {
-        description: "投稿のカテゴリーを選択してください。",
-      })
+      setCategoryError("カテゴリーを1つ以上選択してください。")
+      hasError = true
+    }
+
+    if (hasError) {
       return
     }
 
@@ -413,6 +420,10 @@ export default function BoardPage() {
     setNewPostContent("")
     setNewPostCategories([])
     setIsNewPostDialogOpen(false)
+    // エラーメッセージもリセット
+    setTitleError("")
+    setContentError("")
+    setCategoryError("")
 
     toast.success("投稿が完了しました", {
       description: "あなたの投稿が掲示板に追加されました。",
@@ -432,19 +443,32 @@ export default function BoardPage() {
   const handleSaveEdit = () => {
     if (!editingPost) return
 
+    // エラーメッセージをリセット（編集ダイアログ用にも必要であれば同様に追加）
+    setTitleError("")
+    setContentError("")
+    setCategoryError("")
+
+    let hasError = false
     // 入力検証
     if (!newPostTitle.trim()) {
+      // setTitleError("タイトルを入力してください。") // 必要であれば編集用エラーstateを別途用意
       toast.error("タイトルが入力されていません")
-      return
+      hasError = true
     }
 
     if (!newPostContent.trim()) {
+      // setContentError("内容を入力してください。") // 必要であれば編集用エラーstateを別途用意
       toast.error("内容が入力されていません")
-      return
+      hasError = true
     }
 
     if (newPostCategories.length === 0) {
+      // setCategoryError("カテゴリーを1つ以上選択してください。") // 必要であれば編集用エラーstateを別途用意
       toast.error("カテゴリーが選択されていません")
+      hasError = true
+    }
+
+    if (hasError) {
       return
     }
 
@@ -468,6 +492,10 @@ export default function BoardPage() {
     setNewPostCategories([])
     setEditingPost(null)
     setIsEditPostDialogOpen(false)
+    // エラーメッセージもリセット
+    setTitleError("")
+    setContentError("")
+    setCategoryError("")
 
     toast.success("投稿を更新しました")
   }
@@ -604,7 +632,7 @@ export default function BoardPage() {
           <MessageSquare className="mx-auto h-12 w-12 text-muted-foreground opacity-50" />
           <h3 className="mt-4 text-lg font-medium">投稿がありません</h3>
           <p className="mt-2 text-muted-foreground">検索条件に一致する投稿がないか、まだ投稿がありません。</p>
-          <Button className="mt-4 bg-blue-400 hover:bg-blue-400" onClick={() => setIsNewPostDialogOpen(true)}>
+          <Button className="mt-4 text-white bg-blue-400 hover:bg-blue-600" onClick={() => setIsNewPostDialogOpen(true)}>
             最初の投稿を作成
           </Button>
         </div>
@@ -723,6 +751,38 @@ export default function BoardPage() {
     )
   }
 
+  // 新規投稿ダイアログ
+  const handleNewPostDialogChange = (open: boolean) => {
+    setIsNewPostDialogOpen(open)
+    if (!open) {
+      // ダイアログが閉じる時にエラーメッセージをリセット
+      setTitleError("")
+      setContentError("")
+      setCategoryError("")
+      // フォーム内容もリセットした方が良い場合
+      // setNewPostTitle("")
+      // setNewPostContent("")
+      // setNewPostCategories([])
+    }
+  }
+
+  // 編集ダイアログ
+  const handleEditPostDialogChange = (open: boolean) => {
+    setIsEditPostDialogOpen(open)
+    if (!open) {
+      // ダイアログが閉じる時にエラーメッセージをリセット (編集用エラーstateがあればそれも)
+      setTitleError("") // 新規投稿と共用している場合は注意
+      setContentError("")
+      setCategoryError("")
+      setEditingPost(null) // 編集対象もリセット
+      // フォーム内容もリセット
+      // setNewPostTitle("")
+      // setNewPostContent("")
+      // setNewPostCategories([])
+    }
+  }
+
+
   return (
     <div className="container mx-auto max-w-6xl py-6 px-4 md:px-6 lg:px-8">
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-6">
@@ -796,7 +856,7 @@ export default function BoardPage() {
       </Tabs>
 
       {/* 新規投稿ダイアログ */}
-      <Dialog open={isNewPostDialogOpen} onOpenChange={setIsNewPostDialogOpen}>
+      <Dialog open={isNewPostDialogOpen} onOpenChange={handleNewPostDialogChange}>
         <DialogContent className="sm:max-w-[600px] bg-white">
           <DialogHeader>
             <DialogTitle>新規投稿</DialogTitle>
@@ -814,6 +874,7 @@ export default function BoardPage() {
                 placeholder="投稿のタイトルを入力"
                 maxLength={100}
               />
+              {titleError && <p className="text-sm text-red-500">{titleError}</p>}
             </div>
           </div>
           <div className="grid gap-2">
@@ -834,7 +895,8 @@ export default function BoardPage() {
                 </Badge>
               ))}
             </div>
-            <div className="grid gap-2">
+            {categoryError && <p className="text-sm text-red-500 mt-1">{categoryError}</p>}
+            <div className="grid gap-2 mt-4"> {/* mt-4 を追加してスペースを調整 */}
               <Label htmlFor="content">内容</Label>
               <Textarea
                 id="content"
@@ -843,10 +905,11 @@ export default function BoardPage() {
                 placeholder="投稿の内容を入力"
                 rows={8}
               />
+              {contentError && <p className="text-sm text-red-500">{contentError}</p>}
             </div>
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setIsNewPostDialogOpen(false)}>
+            <Button variant="outline" onClick={() => handleNewPostDialogChange(false)}>
               キャンセル
             </Button>
             <Button onClick={handleAddPost}>投稿する</Button>
@@ -855,7 +918,7 @@ export default function BoardPage() {
       </Dialog>
 
       {/* 編集ダイアログ */}
-      <Dialog open={isEditPostDialogOpen} onOpenChange={setIsEditPostDialogOpen}>
+      <Dialog open={isEditPostDialogOpen} onOpenChange={handleEditPostDialogChange}>
         <DialogContent className="sm:max-w-[600px] bg-white">
           <DialogHeader>
             <DialogTitle>投稿を編集</DialogTitle>

--- a/front/src/components/header.tsx
+++ b/front/src/components/header.tsx
@@ -91,7 +91,7 @@ export default function Header() {
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 dark:border-slate-800 dark:bg-slate-900/95 shadow-sm">
       <div className="container flex h-16 items-center justify-between">
-        <Link href="/" className="flex items-center gap-2 mr-auto">
+        <Link href={logoHref} className="flex items-center gap-2 mr-auto">
           <Image src="/logo.png" alt="Otter Bank Logo" width={36} height={36} className="rounded-full transition-transform hover:scale-110" />
           <span className="font-bold text-lg hidden sm:inline-block text-primary dark:text-primary-foreground">Otter Bank</span>
         </Link>

--- a/front/src/hooks/useAchievements.ts
+++ b/front/src/hooks/useAchievements.ts
@@ -1,0 +1,122 @@
+import { useState, useCallback } from 'react';
+import { toast } from 'sonner';
+// import { type Achievement as FrontendAchievement } from '@/app/collection/page'; // collection/page.tsx から型をインポート
+
+// バックエンドAPIのレスポンス型 (collection/page.tsx と同じものを再定義または共有)
+// もし型定義を共通化したい場合は、types/index.ts のようなファイルに移動することを検討してください。
+type ApiAchievementResponse = {
+  id: number; // DB上の achievement.id
+  original_achievement_id: number;
+  title: string;
+  description: string;
+  category: string;
+  unlocked: boolean;
+  progress: number;
+  image_url: string | null;
+  reward: string | null;
+  tier: number | null;
+  // created_at, updated_at など、APIが返す他のフィールドも必要に応じて追加
+};
+
+/*
+// APIレスポンスをフロントエンドの型に変換するヘルパー関数
+const mapApiToFrontend = (apiAch: ApiAchievementResponse): FrontendAchievement => {
+  return {
+    id: apiAch.original_achievement_id,
+    dbId: apiAch.id,
+    title: apiAch.title,
+    description: apiAch.description,
+    category: apiAch.category,
+    isUnlocked: apiAch.unlocked,
+    progress: apiAch.progress,
+    imageUrl: apiAch.image_url || `/placeholder.svg?height=120&width=120&text=${encodeURIComponent(apiAch.title.substring(0,10))}`,
+    reward: apiAch.reward || undefined,
+    tier: apiAch.tier || undefined,
+  };
+};
+
+type UseAchievementsReturn = {
+  updateAchievement: (
+    achievementOriginalId: number,
+    newProgress: number,
+    isNowUnlocked: boolean
+  ) => Promise<FrontendAchievement | null>;
+  isLoading: boolean;
+  error: string | null;
+};
+
+export const useAchievements = (): UseAchievementsReturn => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const updateAchievement = useCallback(
+    async (
+      achievementOriginalId: number,
+      newProgress: number,
+      isNowUnlocked: boolean
+    ): Promise<FrontendAchievement | null> => {
+      const token = localStorage.getItem('authToken');
+      if (!token) {
+        const msg = '認証情報がありません。実績を更新できませんでした。';
+        console.error(msg);
+        toast.error(msg);
+        setError(msg);
+        return null;
+      }
+
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const response = await fetch(
+          `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/achievements/${achievementOriginalId}`,
+          {
+            method: 'PUT', // または 'PATCH'
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify({
+              progress: newProgress,
+              unlocked: isNowUnlocked,
+            }),
+          }
+        );
+
+        if (!response.ok) {
+          let errorMsg = `実績の更新に失敗しました (Status: ${response.status})`;
+          try {
+            const errorData = await response.json();
+            errorMsg = `実績の更新に失敗しました: ${errorData.errors?.join(', ') || errorData.error || response.statusText}`;
+          } catch (e) {
+            // JSONパースに失敗した場合
+            console.warn("Failed to parse error response as JSON");
+          }
+          console.error(errorMsg, { status: response.status, statusText: response.statusText });
+          toast.error(errorMsg);
+          setError(errorMsg);
+          return null;
+        }
+
+        const updatedApiAchievement: ApiAchievementResponse = await response.json();
+        toast.success(`実績「${updatedApiAchievement.title}」を更新しました！`);
+        
+        const frontendAchievement = mapApiToFrontend(updatedApiAchievement);
+        return frontendAchievement;
+
+      } catch (err) {
+        const catchMsg = '実績の更新中に予期せぬエラーが発生しました。';
+        console.error(catchMsg, err);
+        toast.error(catchMsg);
+        setError(catchMsg);
+        return null;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [] // 依存配列は空でOK (localStorage, process.env は外部依存)
+  );
+
+  return { updateAchievement, isLoading, error };
+};
+*/


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要

各ページ内のバグ修正、実績をユーザーと紐づけした処理を実装しようとしましたが、失敗。

## 主な変更点

### 掲示板ページ (`front/src/app/board/page.tsx`)

*   **投稿機能:**
    *   投稿時に入力検証（タイトル、内容、カテゴリーの必須チェック）を追加しました。
    *   投稿者情報をローカルストレージから取得し、投稿データに含めるようにしました。
*   **削除機能:**
    *   投稿削除確認ダイアログを実装し、投稿を安全に削除できるようにしました。
*   **詳細表示機能:**
    *   投稿詳細ダイアログを実装し、投稿の全文とコメント一覧を表示できるようにしました。
*   **コメント機能:**
    *   投稿詳細ダイアログ内でコメントを投稿できるようにしました。
    *   コメント投稿時にも入力検証（内容の必須チェック）を追加しました。
    *   コメント一覧を表示し、自分のコメントには「(自分)」と表示するようにしました。
*   **UI/UX改善:**

### その他

1.  ローカル環境でアプリケーションを起動します。
2.  ログイン後、掲示板ページ (`/board`) にアクセスします。
3.  以下の機能が期待通りに動作することを確認してください。
    *   新規投稿（タイトル、内容、カテゴリー入力、投稿ボタン）
    *   投稿の編集（編集ボタン、内容変更、更新ボタン）
    *   投稿の削除（削除ボタン、確認ダイアログ）
    *   投稿の詳細表示（詳細ボタン、投稿全文、コメント表示）
    *   コメント投稿（コメント入力、投稿ボタン）
    *   投稿へのいいね/いいね解除
    *   コメントへのいいね/いいね解除
    *   投稿のブックマーク/ブックマーク解除
    *   キーワード検索
    *   カテゴリータブでのフィルタリング
    *   フィルターダイアログでの複数カテゴリー選択フィルタリング
    *   ソートオプションの切り替え
    *   各種操作後のトースト通知
    *   未ログイン時のリダイレクト

## 懸念事項・TODO

*   現在はサンプルデータを使用しているため、バックエンドAPIとの連携が必要です。
    *   投稿、コメントの取得・作成・更新・削除API
    *   いいね、ブックマークの登録・解除API
* エラーハンドリングの強化（API通信エラーなど）。
*  実績データをバックエンドAPIでの処理の実装を実行しましたが、フロント側からうまく読み取れず。
* hookの位置により、エラーが重なりこのPRでは実装前(掲示板修正、ヘッダー修正後)に戻しました。

## レビューに関して
レビューする際には、以下のprefix(接頭辞)を付けましょう。
<!-- for GitHub Copilot review rule -->
[must] → かならず変更してね  
[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)  
[nits] → ささいな指摘(nitpick) 
[ask] → 質問  
[fyi] → 参考情報
<!-- for GitHub Copilot review rule-->
## PRのルール
- まずはDraftでPRを作成する。
- レビューに出せる状態になったらOpenにする。
- レビューなしでのmainブランチへのマージは原則禁止
<!-- I want to review in Japanese. -->