### PR TITLE
実績がユーザーの貯金と連動するように機能追加

### DIFF
--- a/back/app/models/achievement.rb
+++ b/back/app/models/achievement.rb
@@ -1,3 +1,44 @@
 class Achievement < ApplicationRecord
   belongs_to :user
+
+  # 実績の種類を定義
+  enum category: {
+    savings: 0,      # 貯金関連
+    streak: 1,       # 連続記録
+    milestone: 2,    # マイルストーン
+    special: 3       # 特別な実績
+  }
+
+  # 実績のティア（難易度）を定義
+  enum tier: {
+    bronze: 0,
+    silver: 1,
+    gold: 2,
+    platinum: 3
+  }
+
+  validates :title, presence: true
+  validates :description, presence: true
+  validates :category, presence: true
+  validates :tier, presence: true
+  validates :progress_target, presence: true, numericality: { greater_than: 0 }
+  validates :original_achievement_id, presence: true, uniqueness: { scope: :user_id }
+
+  # 実績の進捗を更新するメソッド
+  def update_progress(new_progress)
+    return if unlocked
+
+    self.progress = new_progress
+    if progress >= progress_target
+      self.unlocked = true
+      self.unlocked_at = Time.current
+    end
+    save
+  end
+
+  # 実績の進捗率を計算
+  def progress_percentage
+    return 100 if unlocked
+    ((progress.to_f / progress_target) * 100).round
+  end
 end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -3,12 +3,13 @@ class User < ApplicationRecord
 
     has_many :oauth_providers, dependent: :destroy
     has_many :achievements, dependent: :destroy # ユーザーが獲得した実績
+    has_many :savings, dependent: :destroy
 
     validates :username, presence: true, uniqueness: { case_sensitive: false }, length: { minimum: 3, maximum: 20 }
     validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
     validates :password, presence: true, length: { minimum: 8 }, if: :password_required? # パスワード長を8文字に変更 (フロントエンドと合わせる)
 
-    after_create :create_initial_achievements # ユーザー作成時に初期実績を生成
+    after_create :setup_initial_achievements # ユーザー作成時に初期実績を生成
 
     # OAuthアカウントのみかどうか
   def oauth_only?
@@ -92,53 +93,72 @@ class User < ApplicationRecord
     password_digest.present? || !password.nil?
   end
 
-  def create_initial_achievements
-    # アプリでの実績一覧
-    # 実際のDBテーブルから読み込むとかしたいのですが、どうすればいいかわかりません。
-    # いったん、sampleAchievementsの内容を持ってくる。
+  def setup_initial_achievements
+    achievement_service = AchievementService.new(self)
+    achievement_service.create_initial_achievements
+  end
 
-    defined_achievements_data = [
-      { id: 1, title: "初めての一歩", description: "初めて貯金をしました", category: "savings", imageUrl: "/placeholder.svg?height=120&width=120&text=First+Step", reward: "カワウソの基本表情", tier: 1 },
-      { id: 2, title: "千円貯金", description: "累計1,000円を貯金しました", category: "savings", imageUrl: "/placeholder.svg?height=120&width=120&text=1000+Yen", reward: "カワウソの笑顔", tier: 2 },
-      { id: 3, title: "一万円クラブ", description: "累計10,000円を貯金しました", category: "savings", imageUrl: "/placeholder.svg?height=120&width=120&text=10000+Yen", reward: "カワウソの新しい帽子", tier: 3 },
-      { id: 4, title: "貯金の達人", description: "累計30,000円を貯金しました", category: "savings", imageUrl: "/placeholder.svg?height=120&width=120&text=30000+Yen", reward: "カワウソの新しい環境", tier: 4 },
-      { id: 5, title: "十万円達成", description: "累計100,000円を貯金しました", category: "savings", imageUrl: "/placeholder.svg?height=120&width=120&text=100K+Yen", reward: "カワウソの特別な環境", tier: 5 },
-      { id: 6, title: "半分ミリオネア", description: "累計500,000円を貯金しました", category: "savings", imageUrl: "/placeholder.svg?height=120&width=120&text=500K+Yen", reward: "銀のカワウソ像", tier: 6 },
-      { id: 7, title: "ミリオネア", description: "累計1,000,000円を貯金しました", category: "savings", imageUrl: "/placeholder.svg?height=120&width=120&text=Millionaire", reward: "金のカワウソ像", tier: 7 },
+  def total_savings
+    # ユーザーの総貯金額を計算するロジック
+    savings.sum(:amount)
+  end
 
-      # 継続は力なりシリーズ
-      { id: 50, title: "初日の決意", description: "1日連続でアプリを使用しました", category: "streak", imageUrl: "/placeholder.svg?height=120&width=120&text=Day+1", reward: "継続バッジ（初級）", tier: 1 },
-      { id: 51,  title: "一週間の慣れ", description: "7日連続でアプリを使用しました", category: "streak", imageUrl: "/placeholder.svg?height=120&width=120&text=Week+1", reward: "カワウソのカレンダー", tier:2 },
-      { id: 52, title: "10日間の継続", description: "10日連続でアプリを使用しました", category: "streak", imageUrl: "/placeholder.svg?height=120&width=120&text=10+Days", reward: "継続バッジ（中級）", tier: 3 },
-      { id: 53, title: "半月の努力", description: "15日連続でアプリを使用しました", category: "streak", imageUrl: "/placeholder.svg?height=120&width=120&text=15+Days", reward: "カワウソの特別衣装", tier: 4 },
-      { id: 54, title: "継続の達人", description: "30日連続でアプリを使用しました", category: "streak", imageUrl: "/placeholder.svg?height=120&width=120&text=30+Days", reward: "継続バッジ（金）とカワウソの王冠", tier: 5 },
+  def current_streak
+    return 0 if savings.empty?
 
-      # 節約の達人シリーズ
-      { id: 100, title: "節約の始まり", description: "1ヶ月の支出を前月より10%削減しました", category: "expense", imageUrl: "/placeholder.svg?height=120&width=120&text=Save+10%", reward: "節約バッジ（銅）", tier: 1},
-      { id: 101,  title: "節約の実践者",  description: "1ヶ月の支出を前月より20%削減しました",  category: "expense", imageUrl: "/placeholder.svg?height=120&width=120&text=Save+20%",  reward: "節約バッジ（銀）",  tier: 2 },
-      { id: 102,  title: "節約の達人",  description: "1ヶ月の支出を前月より30%削減しました",  category: "expense", imageUrl: "/placeholder.svg?height=120&width=120&text=Save+30%",  reward: "節約バッジ（金）",  tier: 3 },
+    today = Date.current
+    streak = 0
+    current_date = today
 
-      # 特別な実績
-      { id: 150, title: "予算マスター", description: "3ヶ月連続で予算内に収まりました", category: "special", imageUrl: "/placeholder.svg?height=120&width=120&text=Budget+Master", reward: "予算管理バッジ" },
-      { id: 151, title: "投資家デビュー", description: "初めての投資を行いました", category: "special", imageUrl: "/placeholder.svg?height=120&width=120&text=Investor", reward: "投資家バッジ" },
-      { id: 152, title: "完璧な記録", description: "1ヶ月間毎日支出を記録しました", category: "special", imageUrl: "/placeholder.svg?height=120&width=120&text=Perfect+Record", reward: "記録キーパーバッジ" },
-      { id: 153, title: "目標達成者", description: "設定した貯金目標を達成しました", category: "special", imageUrl: "/placeholder.svg?height=120&width=120&text=Goal+Achiever", reward: "目標達成バッジ" },
-      { id: 154, title: "分析の達人", description: "すべての分析レポートを確認しました", category: "special", imageUrl: "/placeholder.svg?height=120&width=120&text=Analyst", reward: "分析バッジ" }
-    ]
-
-  defined_achievements_data.each do |ach_data|
-      attributes_to_create = {
-        original_achievement_id: ach_data[:id],
-        title: ach_data[:title],
-        description: ach_data[:description],
-        category: ach_data[:category].to_s,
-        image_url: ach_data[:imageUrl],
-        reward: ach_data[:reward],
-        tier: ach_data[:tier],
-        unlocked: false, # 初期状態は未解除
-        progress: 0      # 初期進捗は0
-      }
-      self.achievements.create!(attributes_to_create)
+    # 今日の記録があるか確認
+    has_today_record = savings.exists?(created_at: today.beginning_of_day..today.end_of_day)
+    
+    # 昨日までの記録を確認
+    while true
+      has_record = savings.exists?(created_at: current_date.beginning_of_day..current_date.end_of_day)
+      
+      if has_record
+        streak += 1
+        current_date -= 1.day
+      else
+        break
+      end
     end
+
+    # 今日の記録がある場合は1を加算
+    streak += 1 if has_today_record
+
+    streak
+  end
+
+  def longest_streak
+    return 0 if savings.empty?
+
+    dates = savings.pluck(:created_at).map(&:to_date).uniq.sort
+    return 0 if dates.empty?
+
+    current_streak = 1
+    longest_streak = 1
+    previous_date = dates.first
+
+    dates[1..].each do |date|
+      if date == previous_date + 1.day
+        current_streak += 1
+        longest_streak = [longest_streak, current_streak].max
+      else
+        current_streak = 1
+      end
+      previous_date = date
+    end
+
+    longest_streak
+  end
+
+  def streak_status
+    {
+      current_streak: current_streak,
+      longest_streak: longest_streak,
+      last_record_date: savings.last&.created_at&.to_date
+    }
   end
 end

--- a/back/app/services/achievement_service.rb
+++ b/back/app/services/achievement_service.rb
@@ -1,0 +1,92 @@
+class AchievementService
+  def initialize(user)
+    @user = user
+  end
+
+  # 貯金関連の実績を更新
+  def update_savings_achievements(amount)
+    achievements = @user.achievements.where(category: :savings, unlocked: false)
+    
+    achievements.each do |achievement|
+      case achievement.original_achievement_id
+      when 'first_savings'
+        achievement.update_progress(1) if amount > 0
+      when 'savings_milestone_1000'
+        achievement.update_progress(amount)
+      when 'savings_milestone_10000'
+        achievement.update_progress(amount)
+      when 'savings_milestone_100000'
+        achievement.update_progress(amount)
+      end
+    end
+  end
+
+  # 連続記録の実績を更新
+  def update_streak_achievements(days)
+    achievements = @user.achievements.where(category: :streak, unlocked: false)
+    
+    achievements.each do |achievement|
+      case achievement.original_achievement_id
+      when 'streak_3_days'
+        achievement.update_progress(days)
+      when 'streak_7_days'
+        achievement.update_progress(days)
+      when 'streak_30_days'
+        achievement.update_progress(days)
+      end
+    end
+  end
+
+  # マイルストーンの実績を更新
+  def update_milestone_achievements(total_savings)
+    achievements = @user.achievements.where(category: :milestone, unlocked: false)
+    
+    achievements.each do |achievement|
+      case achievement.original_achievement_id
+      when 'total_savings_1000'
+        achievement.update_progress(total_savings)
+      when 'total_savings_10000'
+        achievement.update_progress(total_savings)
+      when 'total_savings_100000'
+        achievement.update_progress(total_savings)
+      end
+    end
+  end
+
+  # 新規ユーザーに初期実績を作成
+  def create_initial_achievements
+    initial_achievements = [
+      {
+        original_achievement_id: 'first_savings',
+        title: '初めての貯金',
+        description: '初めて貯金を記録しました',
+        category: :savings,
+        tier: :bronze,
+        progress_target: 1,
+        image_url: '/achievements/first_savings.png'
+      },
+      {
+        original_achievement_id: 'savings_milestone_1000',
+        title: '貯金マスター',
+        description: '1,000円の貯金を達成',
+        category: :savings,
+        tier: :silver,
+        progress_target: 1000,
+        image_url: '/achievements/savings_1000.png'
+      },
+      {
+        original_achievement_id: 'streak_3_days',
+        title: '継続は力なり',
+        description: '3日連続で貯金を記録',
+        category: :streak,
+        tier: :bronze,
+        progress_target: 3,
+        image_url: '/achievements/streak_3.png'
+      }
+    ]
+
+    initial_achievements.each do |achievement_data|
+      @user.achievements.create!(achievement_data)
+    end
+  end
+end 

--- a/back/app/services/achievement_service.rb
+++ b/back/app/services/achievement_service.rb
@@ -6,13 +6,14 @@ class AchievementService
   # 貯金関連の実績を更新
   def update_savings_achievements(amount)
     achievements = @user.achievements.where(category: :savings, unlocked: false)
+    cumulative_savings = @user.savings.sum(:amount) # Calculate cumulative savings
     
     achievements.each do |achievement|
       case achievement.original_achievement_id
       when 'first_savings'
         achievement.update_progress(1) if amount > 0
       when 'savings_milestone_1000'
-        achievement.update_progress(amount)
+        achievement.update_progress(cumulative_savings) # Use cumulative savings
       when 'savings_milestone_10000'
         achievement.update_progress(amount)
       when 'savings_milestone_100000'

--- a/front/src/app/achievements/[id]/page.tsx
+++ b/front/src/app/achievements/[id]/page.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { AchievementDetailResponse } from '@/types/achievement';
+import { Progress } from '@/components/ui/progress';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { ArrowLeft } from 'lucide-react';
+
+const tierColors: Record<string, string> = {
+  bronze: 'bg-amber-600',
+  silver: 'bg-gray-400',
+  gold: 'bg-yellow-400',
+  platinum: 'bg-blue-400'
+};
+
+export default function AchievementDetailPage() {
+  const params = useParams();
+  const [data, setData] = useState<AchievementDetailResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchAchievement = async () => {
+      try {
+        const response = await fetch(`/api/v1/achievements/${params.id}`);
+        const achievementData: AchievementDetailResponse = await response.json();
+        setData(achievementData);
+      } catch (error) {
+        console.error('Failed to fetch achievement:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchAchievement();
+  }, [params.id]);
+
+  if (loading) {
+    return <AchievementDetailSkeleton />;
+  }
+
+  if (!data) {
+    return (
+      <div className="container mx-auto py-8">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold mb-4">実績が見つかりません</h1>
+          <Link href="/achievements">
+            <Button variant="outline">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              実績一覧に戻る
+            </Button>
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const { achievement, related_achievements } = data;
+
+  return (
+    <div className="container mx-auto py-8">
+      <div className="mb-8">
+        <Link href="/achievements">
+          <Button variant="outline" className="mb-4">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            実績一覧に戻る
+          </Button>
+        </Link>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+        <div className="lg:col-span-2">
+          <Card className={`${achievement.unlocked ? 'border-2 border-green-500' : ''}`}>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <CardTitle className="text-2xl">{achievement.title}</CardTitle>
+                <Badge className={tierColors[achievement.tier]}>
+                  {achievement.tier}
+                </Badge>
+              </div>
+              <CardDescription className="text-lg">{achievement.description}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-6">
+                <div>
+                  <h3 className="text-lg font-medium mb-2">進捗状況</h3>
+                  <div className="flex justify-between text-sm mb-2">
+                    <span>現在の進捗</span>
+                    <span>{achievement.progress} / {achievement.progress_target}</span>
+                  </div>
+                  <Progress value={achievement.progress_percentage} className="h-4" />
+                </div>
+
+                {achievement.unlocked && (
+                  <div className="text-green-600">
+                    <h3 className="text-lg font-medium mb-2">獲得情報</h3>
+                    <p>獲得日: {new Date(achievement.unlocked_at!).toLocaleDateString()}</p>
+                  </div>
+                )}
+
+                <div>
+                  <h3 className="text-lg font-medium mb-2">報酬</h3>
+                  <p>{achievement.reward}</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <div>
+          <Card>
+            <CardHeader>
+              <CardTitle>関連する実績</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-4">
+                {related_achievements.map(related => (
+                  <Link
+                    key={related.id}
+                    href={`/achievements/${related.id}`}
+                    className="block"
+                  >
+                    <Card className="hover:bg-accent transition-colors">
+                      <CardContent className="pt-6">
+                        <div className="flex justify-between items-center mb-2">
+                          <h4 className="font-medium">{related.title}</h4>
+                          {related.unlocked && (
+                            <Badge variant="outline" className="bg-green-100">
+                              獲得済み
+                            </Badge>
+                          )}
+                        </div>
+                        <Progress value={related.progress_percentage} />
+                      </CardContent>
+                    </Card>
+                  </Link>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AchievementDetailSkeleton() {
+  return (
+    <div className="container mx-auto py-8">
+      <Skeleton className="h-10 w-32 mb-8" />
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+        <div className="lg:col-span-2">
+          <Card>
+            <CardHeader>
+              <Skeleton className="h-8 w-3/4" />
+              <Skeleton className="h-4 w-full mt-2" />
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-6">
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-2/3" />
+                <Skeleton className="h-4 w-1/2" />
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+        <div>
+          <Card>
+            <CardHeader>
+              <Skeleton className="h-6 w-1/3" />
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-4">
+                {[...Array(3)].map((_, i) => (
+                  <Skeleton key={i} className="h-20 w-full" />
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+} 

--- a/front/src/app/achievements/page.tsx
+++ b/front/src/app/achievements/page.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Achievement, AchievementResponse } from '@/types/achievement';
+import { Progress } from '@/components/ui/progress';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+
+const categoryLabels: Record<string, string> = {
+  savings: '貯金',
+  streak: '連続記録',
+  milestone: 'マイルストーン',
+  special: '特別'
+};
+
+const tierColors: Record<string, string> = {
+  bronze: 'bg-amber-600',
+  silver: 'bg-gray-400',
+  gold: 'bg-yellow-400',
+  platinum: 'bg-blue-400'
+};
+
+export default function AchievementsPage() {
+  const [achievements, setAchievements] = useState<Achievement[]>([]);
+  const [summary, setSummary] = useState<AchievementResponse['summary'] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [activeCategory, setActiveCategory] = useState<string>('all');
+
+  useEffect(() => {
+    const fetchAchievements = async () => {
+      try {
+        const response = await fetch('/api/v1/achievements');
+        const data: AchievementResponse = await response.json();
+        setAchievements(data.achievements);
+        setSummary(data.summary);
+      } catch (error) {
+        console.error('Failed to fetch achievements:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchAchievements();
+  }, []);
+
+  const filteredAchievements = activeCategory === 'all'
+    ? achievements
+    : achievements.filter(achievement => achievement.category === activeCategory);
+
+  if (loading) {
+    return <AchievementsSkeleton />;
+  }
+
+  return (
+    <div className="container mx-auto py-8">
+      <h1 className="text-3xl font-bold mb-8">実績一覧</h1>
+      
+      {summary && (
+        <div className="mb-8">
+          <Card>
+            <CardHeader>
+              <CardTitle>実績サマリー</CardTitle>
+              <CardDescription>
+                獲得済み: {summary.unlocked_achievements} / {summary.total_achievements}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-4">
+                {Object.entries(summary.progress_by_category).map(([category, data]) => (
+                  <div key={category} className="space-y-2">
+                    <div className="flex justify-between">
+                      <span className="font-medium">{categoryLabels[category]}</span>
+                      <span>{data.unlocked} / {data.total}</span>
+                    </div>
+                    <Progress value={data.progress_percentage} />
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      <Tabs defaultValue="all" onValueChange={setActiveCategory}>
+        <TabsList className="mb-4">
+          <TabsTrigger value="all">すべて</TabsTrigger>
+          {Object.keys(categoryLabels).map(category => (
+            <TabsTrigger key={category} value={category}>
+              {categoryLabels[category]}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+
+        <TabsContent value={activeCategory}>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {filteredAchievements.map(achievement => (
+              <AchievementCard key={achievement.id} achievement={achievement} />
+            ))}
+          </div>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+function AchievementCard({ achievement }: { achievement: Achievement }) {
+  return (
+    <Card className={`${achievement.unlocked ? 'border-2 border-green-500' : ''}`}>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-lg">{achievement.title}</CardTitle>
+          <Badge className={tierColors[achievement.tier]}>
+            {achievement.tier}
+          </Badge>
+        </div>
+        <CardDescription>{achievement.description}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          <div className="flex justify-between text-sm">
+            <span>進捗状況</span>
+            <span>{achievement.progress} / {achievement.progress_target}</span>
+          </div>
+          <Progress value={achievement.progress_percentage} />
+          {achievement.unlocked && (
+            <div className="text-sm text-green-600">
+              獲得日: {new Date(achievement.unlocked_at!).toLocaleDateString()}
+            </div>
+          )}
+          <div className="text-sm">
+            <span className="font-medium">報酬:</span> {achievement.reward}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function AchievementsSkeleton() {
+  return (
+    <div className="container mx-auto py-8">
+      <Skeleton className="h-8 w-48 mb-8" />
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {[...Array(6)].map((_, i) => (
+          <Card key={i}>
+            <CardHeader>
+              <Skeleton className="h-6 w-3/4" />
+              <Skeleton className="h-4 w-full mt-2" />
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-4 w-full mb-4" />
+              <Skeleton className="h-2 w-full" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+} 

--- a/front/src/types/achievement.ts
+++ b/front/src/types/achievement.ts
@@ -1,0 +1,48 @@
+export type AchievementCategory = 'savings' | 'streak' | 'milestone' | 'special';
+
+export type AchievementTier = 'bronze' | 'silver' | 'gold' | 'platinum';
+
+export interface Achievement {
+  id: number;
+  original_achievement_id: string;
+  title: string;
+  description: string;
+  category: AchievementCategory;
+  unlocked: boolean;
+  progress: number;
+  progress_percentage: number;
+  progress_target: number;
+  image_url: string;
+  reward: string;
+  tier: AchievementTier;
+  created_at: string;
+  updated_at: string;
+  unlocked_at: string | null;
+}
+
+export interface AchievementSummary {
+  total_achievements: number;
+  unlocked_achievements: number;
+  progress_by_category: {
+    [key in AchievementCategory]?: {
+      total: number;
+      unlocked: number;
+      progress_percentage: number;
+    };
+  };
+}
+
+export interface AchievementResponse {
+  achievements: Achievement[];
+  summary: AchievementSummary;
+}
+
+export interface AchievementDetailResponse {
+  achievement: Achievement;
+  related_achievements: {
+    id: number;
+    title: string;
+    progress_percentage: number;
+    unlocked: boolean;
+  }[];
+} 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要
ユーザーの貯金活動を促進するための実績機能を実装しました。ユーザーの行動（貯金、連続記録など）に応じて実績がアンロックされる。

### 主な変更点
バックエンド（Ruby on Rails）
- Achievementモデルの実装
- 実績の種類（貯金、連続記録、マイルストーン、特別）の定義
- ティア（難易度）の定義（bronze, silver, gold, platinum）
- 進捗管理とアンロック処理の実装

- AchievementServiceの実装
- 実績の進捗更新ロジック
- 新規ユーザー向けの初期実績作成
- カテゴリー別の実績更新処理
- Userモデルの拡張
- 連続記録の計算ロジック実装

## レビューに関して
レビューする際には、以下のprefix(接頭辞)を付けましょう。
<!-- for GitHub Copilot review rule -->
[must] → かならず変更してね  
[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)  
[nits] → ささいな指摘(nitpick) 
[ask] → 質問  
[fyi] → 参考情報
<!-- for GitHub Copilot review rule-->
## PRのルール
- まずはDraftでPRを作成する。
- レビューに出せる状態になったらOpenにする。
- レビューなしでのmainブランチへのマージは原則禁止
<!-- I want to review in Japanese. -->