### PR TITLE
掲示板テーブルにuser_id外部キーを追加

### DIFF
--- a/back/app/controllers/api/v1/comments_controller.rb
+++ b/back/app/controllers/api/v1/comments_controller.rb
@@ -1,45 +1,50 @@
 class Api::V1::CommentsController < ApplicationController
   before_action :set_post
-  before_action :set_comment, only: [:show, :update, :destroy]
-  
+  before_action :set_comment, only: [:update, :destroy]
+
+  def skip_authorization?
+    action_name == 'index'
+  end
+
   def index
-    @comments = @post.comments.order(created_at: :desc)
-    render json: @comments
+    @comments = @post.comments.includes(:user).order(created_at: :desc)
+    render json: @comments.map { |comment| comment_json(comment) }
   end
 
   def create
     @comment = @post.comments.new(comment_params)
+    @comment.user = current_api_v1_user
     @comment.likes_count ||= 0
 
     if @comment.save
       @post.increment!(:comments_count)
-      render json: @comment, status: :created
+      render json: comment_json(@comment), status: :created
     else
       render json: @comment.errors, status: :unprocessable_entity
     end
   end
 
   def update
-    unless @comment.user == current_api_v1_user
-      render json: { error: 'Not Authorized' }, status: :forbidden
-        return
+    unless @comment.user_id == current_api_v1_user.id
+      render json: { error: 'コメントの編集権限がありません' }, status: :forbidden
+      return
     end
 
     if @comment.update(comment_params)
-      render json: @comment
+      render json: comment_json(@comment)
     else
       render json: @comment.errors, status: :unprocessable_entity
     end
   end
 
   def destroy
-    unless @comment.user == current_api_v1_user
-      render json: { error: 'Not Authorized' }, status: :forbidden
-        return
+    unless @comment.user_id == current_api_v1_user.id
+      render json: { error: 'コメントの削除権限がありません' }, status: :forbidden
+      return
     end
 
     @comment.destroy
-    @post.decrement!(:comments_count) if @post.comments_count > 0
+    @post.decrement!(:comments_count) if @post.comments_count.to_i > 0
     head :no_content
   end
 
@@ -58,6 +63,20 @@ class Api::V1::CommentsController < ApplicationController
   end
 
   def comment_params
-    params.require(:comment).permit(:content, :author_id, :likes_count)
+    params.require(:comment).permit(:content)
+  end
+
+  def comment_json(comment)
+    {
+      id: comment.id,
+      post_id: comment.post_id,
+      content: comment.content,
+      author: comment.user&.username,
+      author_email: comment.user&.email,
+      user_id: comment.user_id,
+      likes_count: comment.likes_count || 0,
+      created_at: comment.created_at,
+      updated_at: comment.updated_at
+    }
   end
 end

--- a/back/app/controllers/api/v1/likes_controller.rb
+++ b/back/app/controllers/api/v1/likes_controller.rb
@@ -1,12 +1,11 @@
 class Api::V1::LikesController < ApplicationController
-
   def create_post_like
     post = Post.find(params[:post_id])
-    like = post.likes.new(user_email: current_api_v1_user.email, likeable: post)
+    like = post.likes.new(user: current_api_v1_user)
 
     if like.save
       post.increment!(:likes_count)
-      render json: { status: 'success', message: 'Post liked', like:like, likes_count: post.likes_count }, status: :created
+      render json: { status: 'success', message: 'Post liked', likes_count: post.likes_count }, status: :created
     else
       render json: { status: 'error', error: like.errors.full_messages }, status: :unprocessable_entity
     end
@@ -16,14 +15,14 @@ class Api::V1::LikesController < ApplicationController
 
   def destroy_post_like
     post = Post.find(params[:post_id])
-    like = post.likes.find_by(user_email: current_api_v1_user.email, likeable: post)
+    like = post.likes.find_by(user: current_api_v1_user)
 
     if like
       like.destroy
-      post.decrement!(:likes_count) if post.likes_count > 0
-      render json: { status: 'success', message: 'Post unliked', likes_count: post.likes_count }, status: :created
+      post.decrement!(:likes_count) if post.likes_count.to_i > 0
+      render json: { status: 'success', message: 'Post unliked', likes_count: post.likes_count }
     else
-      render json: { error: 'Like not found or not authorized' }, status: :not_found
+      render json: { error: 'Like not found' }, status: :not_found
     end
   rescue ActiveRecord::RecordNotFound
     render json: { error: 'Post not found' }, status: :not_found
@@ -31,7 +30,7 @@ class Api::V1::LikesController < ApplicationController
 
   def create_comment_like
     comment = Comment.find(params[:comment_id])
-    like = comment.likes.find_by(user_email: current_api_v1_user.email, likeable: comment)
+    like = comment.likes.new(user: current_api_v1_user)
 
     if like.save
       comment.increment!(:likes_count)
@@ -45,14 +44,14 @@ class Api::V1::LikesController < ApplicationController
 
   def destroy_comment_like
     comment = Comment.find(params[:comment_id])
-    like = comment.likes.find_by(user_email: current_api_v1_user.email, likeable: comment)
+    like = comment.likes.find_by(user: current_api_v1_user)
 
     if like
       like.destroy
       comment.decrement!(:likes_count) if comment.likes_count.to_i > 0
-      render json: { status: 'success', message: 'Comment unliked', likes_count: comment.likes_count }, status: :created
+      render json: { status: 'success', message: 'Comment unliked', likes_count: comment.likes_count }
     else
-      render json: { error: 'Like not found or not authorized' }, status: :not_found
+      render json: { error: 'Like not found' }, status: :not_found
     end
   rescue ActiveRecord::RecordNotFound
     render json: { error: 'Comment not found' }, status: :not_found

--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -1,14 +1,18 @@
 class Api::V1::PostsController < ApplicationController
-  before_action :authenticate_user!, except: [:index, :show]
+  before_action :authenticate_user!, except: [:index, :show, :increment_views]
   before_action :set_post, only: [:show, :update, :destroy, :increment_views]
-  
+
+  def skip_authorization?
+    action_name.in?(%w[index show increment_views])
+  end
+
   def index
-    @posts = Post.order(created_at: :desc)
-    render json: @posts
+    @posts = Post.includes(:user).order(created_at: :desc)
+    render json: @posts.map { |post| post_json(post) }
   end
 
   def show
-    render json: @post
+    render json: post_json(@post)
   end
 
   def create
@@ -18,30 +22,28 @@ class Api::V1::PostsController < ApplicationController
     @post.views_count ||= 0
 
     if @post.save
-      render json: @post, status: :created
+      render json: post_json(@post), status: :created
     else
       render json: @post.errors, status: :unprocessable_entity
     end
   end
 
   def update
-    authorize @post
-    unless @post.author == current_api_v1_user
-      render json: { error: 'You are not authorized to update this post' }, status: :forbidden
+    unless @post.user_id == current_api_v1_user.id
+      render json: { error: '投稿の編集権限がありません' }, status: :forbidden
       return
     end
-    
+
     if @post.update(post_params)
-      render json: @post
+      render json: post_json(@post)
     else
       render json: @post.errors, status: :unprocessable_entity
     end
   end
 
   def destroy
-    authorize @post
-    unless @post.author == current_api_v1_user
-      render json: { error: 'You are not authorized to delete this post' }, status: :forbidden
+    unless @post.user_id == current_api_v1_user.id
+      render json: { error: '投稿の削除権限がありません' }, status: :forbidden
       return
     end
 
@@ -63,6 +65,22 @@ class Api::V1::PostsController < ApplicationController
   end
 
   def post_params
-    params.require(:post).permit(:title, :content, :category_ids => []).merge(author_id: current_api_v1_user.id)
+    params.require(:post).permit(:title, :content, category_ids: [])
+  end
+
+  def post_json(post)
+    {
+      id: post.id,
+      title: post.title,
+      content: post.content,
+      author: post.user&.username,
+      author_email: post.user&.email,
+      user_id: post.user_id,
+      likes_count: post.likes_count || 0,
+      comments_count: post.comments_count || 0,
+      views_count: post.views_count || 0,
+      created_at: post.created_at,
+      updated_at: post.updated_at
+    }
   end
 end

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -33,9 +33,13 @@ class ApplicationController < ActionController::API
     !!current_user
   end
 
-  # authorize メソッドを追加して統一
-  def authorize
-    render json: { message: 'ログインが必要です' }, status: :unauthorized unless logged_in?
+  # コントローラーから統一的にアクセスするためのヘルパー
+  def current_api_v1_user
+    @current_user
+  end
+
+  def authenticate_user!
+    authorize_request unless @current_user
   end
 
   private

--- a/back/app/models/bookmark.rb
+++ b/back/app/models/bookmark.rb
@@ -1,3 +1,6 @@
 class Bookmark < ApplicationRecord
   belongs_to :post
+  belongs_to :user
+
+  validates :user_id, uniqueness: { scope: :post_id, message: "は既にブックマーク済みです" }
 end

--- a/back/app/models/comment.rb
+++ b/back/app/models/comment.rb
@@ -1,3 +1,7 @@
 class Comment < ApplicationRecord
   belongs_to :post
+  belongs_to :user
+  has_many :likes, as: :likeable, dependent: :destroy
+
+  validates :content, presence: true
 end

--- a/back/app/models/like.rb
+++ b/back/app/models/like.rb
@@ -1,3 +1,6 @@
 class Like < ApplicationRecord
   belongs_to :likeable, polymorphic: true
+  belongs_to :user
+
+  validates :user_id, uniqueness: { scope: [:likeable_type, :likeable_id], message: "は既にいいね済みです" }
 end

--- a/back/app/models/post.rb
+++ b/back/app/models/post.rb
@@ -1,10 +1,14 @@
 class Post < ApplicationRecord
   # アソシエーション
+  belongs_to :user
   has_many :comments, dependent: :destroy
   has_many :likes, as: :likeable, dependent: :destroy
+  has_many :bookmarks, dependent: :destroy
+  has_many :post_categories, dependent: :destroy
+  has_many :categories, through: :post_categories
 
   # バリデーション
-  validates :title, :content, :author, presence: true
+  validates :title, :content, presence: true
 
   # メソッド
   def increment_views!

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -5,6 +5,10 @@ class User < ApplicationRecord
     has_many :achievements, dependent: :destroy # ユーザーが獲得した実績
     has_many :savings_goals, dependent: :destroy
     has_many :transactions, dependent: :destroy
+    has_many :posts, dependent: :destroy
+    has_many :comments, dependent: :destroy
+    has_many :likes, dependent: :destroy
+    has_many :bookmarks, dependent: :destroy
     
     # 貯金関連のアソシエーション（transactions の中から income タイプを取得）
     has_many :savings, -> { where(transaction_type: 'income') }, class_name: 'Transaction'

--- a/back/db/migrate/20260216100000_add_user_id_to_board_tables.rb
+++ b/back/db/migrate/20260216100000_add_user_id_to_board_tables.rb
@@ -1,0 +1,19 @@
+class AddUserIdToBoardTables < ActiveRecord::Migration[7.1]
+  def change
+    # posts テーブルに user_id を追加
+    add_reference :posts, :user, null: true, foreign_key: true
+
+    # comments テーブルに user_id を追加
+    add_reference :comments, :user, null: true, foreign_key: true
+
+    # likes テーブルに user_id を追加
+    add_reference :likes, :user, null: true, foreign_key: true
+
+    # bookmarks テーブルに user_id を追加
+    add_reference :bookmarks, :user, null: true, foreign_key: true
+
+    # 重複いいね・ブックマーク防止のユニークインデックス
+    add_index :likes, [:user_id, :likeable_type, :likeable_id], unique: true, name: 'index_likes_on_user_and_likeable'
+    add_index :bookmarks, [:user_id, :post_id], unique: true, name: 'index_bookmarks_on_user_and_post'
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_06_15_082344) do
+ActiveRecord::Schema[7.1].define(version: 2026_02_16_100000) do
   create_table "achievements", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "original_achievement_id", null: false
@@ -39,7 +39,10 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_15_082344) do
     t.string "user_email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "user_id"
     t.index ["post_id"], name: "index_bookmarks_on_post_id"
+    t.index ["user_id", "post_id"], name: "index_bookmarks_on_user_and_post", unique: true
+    t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
   create_table "categories", force: :cascade do |t|
@@ -56,7 +59,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_15_082344) do
     t.integer "likes_count"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "user_id"
     t.index ["post_id"], name: "index_comments_on_post_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "likes", force: :cascade do |t|
@@ -65,7 +70,10 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_15_082344) do
     t.string "user_email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "user_id"
     t.index ["likeable_type", "likeable_id"], name: "index_likes_on_likeable"
+    t.index ["user_id", "likeable_type", "likeable_id"], name: "index_likes_on_user_and_likeable", unique: true
+    t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
   create_table "oauth_providers", force: :cascade do |t|
@@ -99,6 +107,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_15_082344) do
     t.integer "views_count"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
   create_table "savings_goals", force: :cascade do |t|
@@ -148,10 +158,14 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_15_082344) do
 
   add_foreign_key "achievements", "users"
   add_foreign_key "bookmarks", "posts"
+  add_foreign_key "bookmarks", "users"
   add_foreign_key "comments", "posts"
+  add_foreign_key "comments", "users"
+  add_foreign_key "likes", "users"
   add_foreign_key "oauth_providers", "users"
   add_foreign_key "post_categories", "categories"
   add_foreign_key "post_categories", "posts"
+  add_foreign_key "posts", "users"
   add_foreign_key "savings_goals", "users"
   add_foreign_key "transactions", "users"
   add_foreign_key "user_actions", "users"

--- a/back/spec/factories/bookmarks.rb
+++ b/back/spec/factories/bookmarks.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :bookmark do
-    post { nil }
-    user_email { "MyString" }
+    association :post
+    association :user
   end
 end

--- a/back/spec/factories/comments.rb
+++ b/back/spec/factories/comments.rb
@@ -1,9 +1,8 @@
 FactoryBot.define do
   factory :comment do
     association :post
+    association :user
     sequence(:content) { |n| "これはコメントです。#{n}" }
-    sequence(:author) { |n| "コメントユーザー#{n}" }
-    sequence(:author_email) { |n| "comment_user#{n}@example.com" }
     likes_count { 0 }
   end
 end

--- a/back/spec/factories/likes.rb
+++ b/back/spec/factories/likes.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :like do
-    likeable { nil }
-    user_email { "MyString" }
+    association :user
+    association :likeable, factory: :post
   end
 end

--- a/back/spec/factories/posts.rb
+++ b/back/spec/factories/posts.rb
@@ -1,9 +1,8 @@
 FactoryBot.define do
   factory :post do
+    association :user
     sequence(:title) { |n| "投稿タイトル#{n}" }
     sequence(:content) { |n| "これは投稿の内容です。#{n}" }
-    sequence(:author) { |n| "ユーザー#{n}" }
-    sequence(:author_email) { |n| "user#{n}@example.com" }
     likes_count { 0 }
     comments_count { 0 }
     views_count { 0 }

--- a/back/spec/factories/users.rb
+++ b/back/spec/factories/users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    sequence(:username) { |n| "testuser#{n}" }
+    sequence(:email) { |n| "test#{n}@example.com" }
+    password { "password123" }
+  end
+end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要
- 掲示板関連テーブル（posts, comments, likes, bookmarks）が文字列の author_email/user_email を使用していた構造的問題を修正し、user_id 外部キーによる proper なアソシエーションに移行しました。

## 詳細な変更点
- マイグレーション: 4テーブルに user_id カラム + ユニークインデックス追加
- モデル: User に has_many :posts/:comments/:likes/:bookmarks を追加
- モデル: Post/Comment に belongs_to :user、Like/Bookmark にバリデーション追加
- コントローラー: current_api_v1_user ヘルパーを ApplicationController に追加
- コントローラー: Posts/Comments/Likes を user_id ベースの認可に修正
- ファクトリー: user アソシエーションに対応、users ファクトリー新規作成

## 修正された問題
- PostsController が current_api_v1_user.posts.new() を使用しているが、User モデルに has_many :posts がなかった
- CommentsController が @comment.user を参照しているが、Comment に belongs_to :user がなかった
- Likes/Bookmarks が user_email 文字列で検索していたが、user_id 外部キーに移行
- いいね・ブックマークの重複防止ユニークインデックスが存在しなかった

## レビューに関して
レビューする際には、以下のprefix(接頭辞)を付けましょう。
<!-- for GitHub Copilot review rule -->
[must] → かならず変更してね  
[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)  
[nits] → ささいな指摘(nitpick) 
[ask] → 質問  
[fyi] → 参考情報
<!-- for GitHub Copilot review rule-->

## PRのルール
- まずはDraftでPRを作成する。
- レビューに出せる状態になったらOpenにする。
- レビューなしでのmainブランチへのマージは原則禁止
<!-- I want to review in Japanese. -->