### PR TITLE
実績（Achievement）サービスをトランザクション登録と連携

### DIFF
--- a/back/app/controllers/api/v1/transactions_controller.rb
+++ b/back/app/controllers/api/v1/transactions_controller.rb
@@ -35,6 +35,7 @@ module Api
         @transaction = current_api_v1_user.transactions.new(transaction_params)
 
         if @transaction.save
+          update_achievements_for_transaction(@transaction)
           render json: @transaction, status: :created
         else
           render json: @transaction.errors, status: :unprocessable_entity
@@ -43,6 +44,7 @@ module Api
 
       def update
         if @transaction.update(transaction_params)
+          update_achievements_for_transaction(@transaction)
           render json: @transaction
         else
           render json: @transaction.errors, status: :unprocessable_entity
@@ -50,7 +52,9 @@ module Api
       end
 
       def destroy
+        was_income = @transaction.income?
         @transaction.destroy
+        update_milestone_achievements_after_destroy if was_income
         head :no_content
       end
 
@@ -64,6 +68,26 @@ module Api
 
       def transaction_params
         params.expect(transaction: %i[amount transaction_type category description date])
+      end
+
+      # 収入取引の登録・更新後に実績を更新する
+      def update_achievements_for_transaction(transaction)
+        return unless transaction.income?
+
+        service = AchievementService.new(current_api_v1_user)
+        service.update_savings_achievements(transaction.amount)
+        service.update_milestone_achievements
+        service.update_streak_achievements(current_api_v1_user.current_streak)
+      rescue StandardError => e
+        Rails.logger.error "実績更新エラー: #{e.message}"
+      end
+
+      # 収入取引の削除後にマイルストーン実績を再計算する
+      def update_milestone_achievements_after_destroy
+        service = AchievementService.new(current_api_v1_user)
+        service.update_milestone_achievements
+      rescue StandardError => e
+        Rails.logger.error "実績更新エラー（削除後）: #{e.message}"
       end
     end
   end

--- a/back/app/models/transaction.rb
+++ b/back/app/models/transaction.rb
@@ -3,10 +3,10 @@
 class Transaction < ApplicationRecord
   belongs_to :user
 
-  # 取引タイプを定義
+  # 取引タイプを定義（string列のためキー文字列で格納）
   enum :transaction_type, {
-    income: 0,    # 収入（貯金）
-    expense: 1    # 支出
+    income: 'income',    # 収入（貯金）
+    expense: 'expense'   # 支出
   }
 
   validates :amount, presence: true, numericality: { greater_than: 0 }

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -98,14 +98,12 @@ class User < ApplicationRecord
     username.length >= 3 ? username : "#{username}#{SecureRandom.hex(2)}"
   end
 
-  def password_required
-    password_digest.present? || !password.nil?
-  end
-
   def setup_initial_achievements
     achievement_service = AchievementService.new(self)
     achievement_service.create_initial_achievements
   end
+
+  public
 
   def total_savings
     # ユーザーの総貯金額を計算するロジック

--- a/back/db/migrate/20260313133015_fix_transaction_type_enum_values.rb
+++ b/back/db/migrate/20260313133015_fix_transaction_type_enum_values.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class FixTransactionTypeEnumValues < ActiveRecord::Migration[8.1]
+  def up
+    # enumの整数値（"0", "1"）を文字列キー（"income", "expense"）に変換
+    execute "UPDATE transactions SET transaction_type = 'income' WHERE transaction_type = '0'"
+    execute "UPDATE transactions SET transaction_type = 'expense' WHERE transaction_type = '1'"
+  end
+
+  def down
+    execute "UPDATE transactions SET transaction_type = '0' WHERE transaction_type = 'income'"
+    execute "UPDATE transactions SET transaction_type = '1' WHERE transaction_type = 'expense'"
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,163 +10,163 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 20_260_216_100_000) do
-  create_table 'achievements', force: :cascade do |t|
-    t.integer 'user_id', null: false
-    t.string 'original_achievement_id', null: false
-    t.string 'title', null: false
-    t.text 'description'
-    t.integer 'category', default: 0, null: false
-    t.integer 'tier', default: 0, null: false
-    t.boolean 'unlocked', default: false, null: false
-    t.integer 'progress', default: 0, null: false
-    t.integer 'progress_target', null: false
-    t.string 'image_url'
-    t.string 'reward'
-    t.datetime 'unlocked_at'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['category'], name: 'index_achievements_on_category'
-    t.index ['created_at'], name: 'index_achievements_on_created_at'
-    t.index ['tier'], name: 'index_achievements_on_tier'
-    t.index ['unlocked'], name: 'index_achievements_on_unlocked'
-    t.index %w[user_id original_achievement_id], name: 'index_achievements_on_user_and_original_id', unique: true
-    t.index ['user_id'], name: 'index_achievements_on_user_id'
+ActiveRecord::Schema[8.1].define(version: 2026_03_13_133015) do
+  create_table "achievements", force: :cascade do |t|
+    t.integer "category", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.string "image_url"
+    t.string "original_achievement_id", null: false
+    t.integer "progress", default: 0, null: false
+    t.integer "progress_target", null: false
+    t.string "reward"
+    t.integer "tier", default: 0, null: false
+    t.string "title", null: false
+    t.boolean "unlocked", default: false, null: false
+    t.datetime "unlocked_at"
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["category"], name: "index_achievements_on_category"
+    t.index ["created_at"], name: "index_achievements_on_created_at"
+    t.index ["tier"], name: "index_achievements_on_tier"
+    t.index ["unlocked"], name: "index_achievements_on_unlocked"
+    t.index ["user_id", "original_achievement_id"], name: "index_achievements_on_user_and_original_id", unique: true
+    t.index ["user_id"], name: "index_achievements_on_user_id"
   end
 
-  create_table 'bookmarks', force: :cascade do |t|
-    t.integer 'post_id', null: false
-    t.string 'user_email'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.integer 'user_id'
-    t.index ['post_id'], name: 'index_bookmarks_on_post_id'
-    t.index %w[user_id post_id], name: 'index_bookmarks_on_user_and_post', unique: true
-    t.index ['user_id'], name: 'index_bookmarks_on_user_id'
+  create_table "bookmarks", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "post_id", null: false
+    t.datetime "updated_at", null: false
+    t.string "user_email"
+    t.integer "user_id"
+    t.index ["post_id"], name: "index_bookmarks_on_post_id"
+    t.index ["user_id", "post_id"], name: "index_bookmarks_on_user_and_post", unique: true
+    t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table 'categories', force: :cascade do |t|
-    t.string 'name'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "categories", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "name"
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'comments', force: :cascade do |t|
-    t.integer 'post_id', null: false
-    t.text 'content'
-    t.string 'author'
-    t.string 'author_email'
-    t.integer 'likes_count'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.integer 'user_id'
-    t.index ['post_id'], name: 'index_comments_on_post_id'
-    t.index ['user_id'], name: 'index_comments_on_user_id'
+  create_table "comments", force: :cascade do |t|
+    t.string "author"
+    t.string "author_email"
+    t.text "content"
+    t.datetime "created_at", null: false
+    t.integer "likes_count"
+    t.integer "post_id", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.index ["post_id"], name: "index_comments_on_post_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
-  create_table 'likes', force: :cascade do |t|
-    t.string 'likeable_type', null: false
-    t.integer 'likeable_id', null: false
-    t.string 'user_email'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.integer 'user_id'
-    t.index %w[likeable_type likeable_id], name: 'index_likes_on_likeable'
-    t.index %w[user_id likeable_type likeable_id], name: 'index_likes_on_user_and_likeable', unique: true
-    t.index ['user_id'], name: 'index_likes_on_user_id'
+  create_table "likes", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "likeable_id", null: false
+    t.string "likeable_type", null: false
+    t.datetime "updated_at", null: false
+    t.string "user_email"
+    t.integer "user_id"
+    t.index ["likeable_type", "likeable_id"], name: "index_likes_on_likeable"
+    t.index ["user_id", "likeable_type", "likeable_id"], name: "index_likes_on_user_and_likeable", unique: true
+    t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
-  create_table 'oauth_providers', force: :cascade do |t|
-    t.integer 'user_id', null: false
-    t.string 'provider'
-    t.string 'uid'
-    t.string 'access_token'
-    t.string 'refresh_token'
-    t.datetime 'expires_at'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['user_id'], name: 'index_oauth_providers_on_user_id'
+  create_table "oauth_providers", force: :cascade do |t|
+    t.string "access_token"
+    t.datetime "created_at", null: false
+    t.datetime "expires_at"
+    t.string "provider"
+    t.string "refresh_token"
+    t.string "uid"
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["user_id"], name: "index_oauth_providers_on_user_id"
   end
 
-  create_table 'post_categories', force: :cascade do |t|
-    t.integer 'post_id', null: false
-    t.integer 'category_id', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['category_id'], name: 'index_post_categories_on_category_id'
-    t.index ['post_id'], name: 'index_post_categories_on_post_id'
+  create_table "post_categories", force: :cascade do |t|
+    t.integer "category_id", null: false
+    t.datetime "created_at", null: false
+    t.integer "post_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_post_categories_on_category_id"
+    t.index ["post_id"], name: "index_post_categories_on_post_id"
   end
 
-  create_table 'posts', force: :cascade do |t|
-    t.string 'title'
-    t.text 'content'
-    t.string 'author'
-    t.string 'author_email'
-    t.integer 'likes_count'
-    t.integer 'comments_count'
-    t.integer 'views_count'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.integer 'user_id'
-    t.index ['user_id'], name: 'index_posts_on_user_id'
+  create_table "posts", force: :cascade do |t|
+    t.string "author"
+    t.string "author_email"
+    t.integer "comments_count"
+    t.text "content"
+    t.datetime "created_at", null: false
+    t.integer "likes_count"
+    t.string "title"
+    t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.integer "views_count"
+    t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
-  create_table 'savings_goals', force: :cascade do |t|
-    t.string 'title'
-    t.decimal 'target_amount'
-    t.decimal 'current_amount'
-    t.date 'deadline'
-    t.integer 'user_id', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['user_id'], name: 'index_savings_goals_on_user_id'
+  create_table "savings_goals", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.decimal "current_amount"
+    t.date "deadline"
+    t.decimal "target_amount"
+    t.string "title"
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["user_id"], name: "index_savings_goals_on_user_id"
   end
 
-  create_table 'transactions', force: :cascade do |t|
-    t.decimal 'amount'
-    t.string 'transaction_type'
-    t.string 'category'
-    t.text 'description'
-    t.integer 'user_id', null: false
-    t.datetime 'date'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['user_id'], name: 'index_transactions_on_user_id'
+  create_table "transactions", force: :cascade do |t|
+    t.decimal "amount"
+    t.string "category"
+    t.datetime "created_at", null: false
+    t.datetime "date"
+    t.text "description"
+    t.string "transaction_type"
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["user_id"], name: "index_transactions_on_user_id"
   end
 
-  create_table 'user_actions', force: :cascade do |t|
-    t.integer 'user_id', null: false
-    t.string 'action_type', null: false
-    t.decimal 'amount', precision: 10, scale: 2
-    t.text 'description'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['action_type'], name: 'index_user_actions_on_action_type'
-    t.index ['created_at'], name: 'index_user_actions_on_created_at'
-    t.index %w[user_id created_at], name: 'index_user_actions_on_user_id_and_created_at'
-    t.index ['user_id'], name: 'index_user_actions_on_user_id'
+  create_table "user_actions", force: :cascade do |t|
+    t.string "action_type", null: false
+    t.decimal "amount", precision: 10, scale: 2
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["action_type"], name: "index_user_actions_on_action_type"
+    t.index ["created_at"], name: "index_user_actions_on_created_at"
+    t.index ["user_id", "created_at"], name: "index_user_actions_on_user_id_and_created_at"
+    t.index ["user_id"], name: "index_user_actions_on_user_id"
   end
 
-  create_table 'users', force: :cascade do |t|
-    t.string 'email'
-    t.string 'password_digest'
-    t.string 'name'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.string 'username'
+  create_table "users", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "email"
+    t.string "name"
+    t.string "password_digest"
+    t.datetime "updated_at", null: false
+    t.string "username"
   end
 
-  add_foreign_key 'achievements', 'users'
-  add_foreign_key 'bookmarks', 'posts'
-  add_foreign_key 'bookmarks', 'users'
-  add_foreign_key 'comments', 'posts'
-  add_foreign_key 'comments', 'users'
-  add_foreign_key 'likes', 'users'
-  add_foreign_key 'oauth_providers', 'users'
-  add_foreign_key 'post_categories', 'categories'
-  add_foreign_key 'post_categories', 'posts'
-  add_foreign_key 'posts', 'users'
-  add_foreign_key 'savings_goals', 'users'
-  add_foreign_key 'transactions', 'users'
-  add_foreign_key 'user_actions', 'users'
+  add_foreign_key "achievements", "users"
+  add_foreign_key "bookmarks", "posts"
+  add_foreign_key "bookmarks", "users"
+  add_foreign_key "comments", "posts"
+  add_foreign_key "comments", "users"
+  add_foreign_key "likes", "users"
+  add_foreign_key "oauth_providers", "users"
+  add_foreign_key "post_categories", "categories"
+  add_foreign_key "post_categories", "posts"
+  add_foreign_key "posts", "users"
+  add_foreign_key "savings_goals", "users"
+  add_foreign_key "transactions", "users"
+  add_foreign_key "user_actions", "users"
 end

--- a/back/spec/requests/api/v1/transactions_spec.rb
+++ b/back/spec/requests/api/v1/transactions_spec.rb
@@ -69,6 +69,57 @@ RSpec.describe 'Api::V1::Transactions', type: :request do
       post '/api/v1/transactions', params: { transaction: { amount: nil } }, headers: headers
       expect(response).to have_http_status(:unprocessable_entity)
     end
+
+    context '実績連携' do
+      it '収入取引を作成すると初めての貯金実績が解除される' do
+        post '/api/v1/transactions',
+             params: { transaction: { amount: 5000, transaction_type: 'income', description: '給料', category: '給与',
+                                      date: Date.current } },
+             headers: headers
+
+        expect(response).to have_http_status(:created)
+        first_savings = user.achievements.find_by(original_achievement_id: 'first_savings')
+        expect(first_savings.reload.unlocked).to be true
+      end
+
+      it '収入取引を作成するとマイルストーン実績の進捗が更新される' do
+        post '/api/v1/transactions',
+             params: { transaction: { amount: 5000, transaction_type: 'income', description: '給料', category: '給与',
+                                      date: Date.current } },
+             headers: headers
+
+        milestone = user.achievements.find_by(original_achievement_id: 'savings_milestone_5000')
+        expect(milestone.reload.unlocked).to be true
+      end
+
+      it '支出取引を作成しても貯金実績は更新されない' do
+        post '/api/v1/transactions',
+             params: { transaction: { amount: 1000, transaction_type: 'expense', description: '食費', category: '食費',
+                                      date: Date.current } },
+             headers: headers
+
+        expect(response).to have_http_status(:created)
+        first_savings = user.achievements.find_by(original_achievement_id: 'first_savings')
+        expect(first_savings.reload.unlocked).to be false
+      end
+    end
+  end
+
+  describe 'PATCH /api/v1/transactions/:id - 実績連携' do
+    let!(:income_transaction) do
+      create(:transaction, user: user, amount: 1000, transaction_type: :income, description: '給料', category: '給与',
+                           date: Date.current)
+    end
+
+    it '収入取引を更新するとマイルストーン実績が再計算される' do
+      patch "/api/v1/transactions/#{income_transaction.id}",
+            params: { transaction: { amount: 30_000 } },
+            headers: headers
+
+      expect(response).to have_http_status(:ok)
+      milestone = user.achievements.find_by(original_achievement_id: 'savings_milestone_30000')
+      expect(milestone.reload.unlocked).to be true
+    end
   end
 
   describe 'PATCH /api/v1/transactions/:id' do


### PR DESCRIPTION
- TransactionsController に収入取引登録・更新・削除後の実績更新処理を追加
  - create/update: 収入取引のみ貯金実績・マイルストーン・連続記録実績を更新
  - destroy: 収入取引削除後にマイルストーン実績を再計算
- Transaction enum バグ修正: string 列に整数値を使っていたため income? が 常に false を返す問題を修正（{ income: 'income', expense: 'expense' } に変更）
- マイグレーション追加: DB 内の "0"/"1" を "income"/"expense" に変換
- User#total_savings / current_streak を private から public に戻す
- User の重複メソッド password_required を削除（password_required? が正）
- transactions_spec に実績連携の統合テスト 4 ケースを追加

<!-- I want to review in Japanese. -->
## 概要
xxxの改修をしました。

## 詳細な変更点
- [x] xxxxxx

## 修正された問題

-
-
-
-

## レビューに関して
レビューする際には、以下のprefix(接頭辞)を付けましょう。
<!-- for GitHub Copilot review rule -->
[must] → かならず変更してね  
[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)  
[nits] → ささいな指摘(nitpick) 
[ask] → 質問  
[fyi] → 参考情報
<!-- for GitHub Copilot review rule-->
## PRのルール
- まずはDraftでPRを作成する。
- レビューに出せる状態になったらOpenにする。
- レビューなしでのmainブランチへのマージは原則禁止
<!-- I want to review in Japanese. -->