### PR TITLE
feat: トランザクション削除に確認ダイアログを追加する

### DIFF
--- a/front/src/app/dashboard/page.tsx
+++ b/front/src/app/dashboard/page.tsx
@@ -38,6 +38,17 @@ import OtterAnimation from "@/components/otter-animation"
 import ExpensePieChart from "@/components/expense-pie-chart"
 import MonthlyTrend from "@/components/monthly-trend"
 import { Tutorial } from "@/components/tutorial"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
 import { cn } from "@/lib/utils"
 import { useRouter } from "next/navigation"
 import { useAuth } from "@/hooks/useAuth"
@@ -483,14 +494,34 @@ export default function DashboardPage() {
                             {format(new Date(transaction.date), "yyyy/MM/dd")}
                           </div>
                         </div>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => deleteTransaction(transaction.id)}
-                          className="text-muted-foreground hover:text-destructive"
-                        >
-                          削除
-                        </Button>
+                        <AlertDialog>
+                          <AlertDialogTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="text-muted-foreground hover:text-destructive"
+                            >
+                              削除
+                            </Button>
+                          </AlertDialogTrigger>
+                          <AlertDialogContent>
+                            <AlertDialogHeader>
+                              <AlertDialogTitle>取引を削除しますか？</AlertDialogTitle>
+                              <AlertDialogDescription>
+                                この操作は取り消せません。取引履歴から完全に削除されます。
+                              </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter>
+                              <AlertDialogCancel>キャンセル</AlertDialogCancel>
+                              <AlertDialogAction
+                                onClick={() => deleteTransaction(transaction.id)}
+                                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                              >
+                                削除する
+                              </AlertDialogAction>
+                            </AlertDialogFooter>
+                          </AlertDialogContent>
+                        </AlertDialog>
                       </div>
                     </div>
                   ))}


### PR DESCRIPTION
## 概要
取引履歴の削除ボタンに確認ダイアログを追加しました。誤操作による意図しない削除を防ぐための改修です。

## 詳細な変更点
- [x] 削除ボタンを `AlertDialog`（shadcn/ui）でラップ
- [x] ダイアログに「取引を削除しますか？」タイトルと「この操作は取り消せません」説明文を表示
- [x] 「キャンセル」ボタンでダイアログを閉じる
- [x] 「削除する」ボタン（`bg-destructive`）で削除実行

## 修正された問題

- fix #155

## レビューに関して
レビューする際には、以下のprefix(接頭辞)を付けましょう。
[must] → かならず変更してね  
[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)  
[nits] → ささいな指摘(nitpick) 
[ask] → 質問  
[fyi] → 参考情報

## PRのルール
- まずはDraftでPRを作成する。
- レビューに出せる状態になったらOpenにする。
- レビューなしでのmainブランチへのマージは原則禁止