### PR TITLE
feat: SavingsGoal・Transaction モデルにバリデーションを追加する

### DIFF
--- a/back/app/models/savings_goal.rb
+++ b/back/app/models/savings_goal.rb
@@ -2,4 +2,21 @@
 
 class SavingsGoal < ApplicationRecord
   belongs_to :user
+
+  validates :title, presence: true
+  validates :target_amount, presence: true, numericality: { greater_than: 0 }
+  validates :current_amount, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :deadline, presence: true
+
+  validate :current_amount_within_target
+
+  private
+
+  def current_amount_within_target
+    return unless current_amount.present? && target_amount.present?
+
+    return unless current_amount > target_amount
+
+    errors.add(:current_amount, 'は目標金額以下である必要があります')
+  end
 end

--- a/back/app/models/transaction.rb
+++ b/back/app/models/transaction.rb
@@ -11,4 +11,6 @@ class Transaction < ApplicationRecord
 
   validates :amount, presence: true, numericality: { greater_than: 0 }
   validates :description, presence: true
+  validates :transaction_type, presence: true
+  validates :date, presence: true
 end

--- a/back/spec/models/savings_goal_spec.rb
+++ b/back/spec/models/savings_goal_spec.rb
@@ -6,31 +6,56 @@ RSpec.describe SavingsGoal, type: :model do
   # アソシエーション
   it { should belong_to(:user) }
 
+  # バリデーション
+  it { should validate_presence_of(:title) }
+  it { should validate_presence_of(:target_amount) }
+  it { should validate_presence_of(:deadline) }
+  it { should validate_numericality_of(:target_amount).is_greater_than(0) }
+  it { should validate_numericality_of(:current_amount).is_greater_than_or_equal_to(0).allow_nil }
+
   describe 'ファクトリー' do
     it '有効なファクトリーを持つ' do
       expect(build(:savings_goal)).to be_valid
     end
   end
 
-  describe '属性' do
-    it 'title属性を持つ' do
-      goal = SavingsGoal.new
-      expect(goal).to respond_to(:title)
+  describe 'current_amountのバリデーション' do
+    it 'current_amountがtarget_amount以下の場合は有効' do
+      goal = build(:savings_goal, target_amount: 100_000, current_amount: 50_000)
+      expect(goal).to be_valid
     end
 
-    it 'target_amount属性を持つ' do
-      goal = SavingsGoal.new
-      expect(goal).to respond_to(:target_amount)
+    it 'current_amountがtarget_amountと等しい場合は有効' do
+      goal = build(:savings_goal, target_amount: 100_000, current_amount: 100_000)
+      expect(goal).to be_valid
     end
 
-    it 'current_amount属性を持つ' do
-      goal = SavingsGoal.new
-      expect(goal).to respond_to(:current_amount)
+    it 'current_amountがtarget_amountを超える場合は無効' do
+      goal = build(:savings_goal, target_amount: 100_000, current_amount: 100_001)
+      expect(goal).not_to be_valid
+      expect(goal.errors[:current_amount]).to include('は目標金額以下である必要があります')
     end
 
-    it 'deadline属性を持つ' do
-      goal = SavingsGoal.new
-      expect(goal).to respond_to(:deadline)
+    it 'current_amountが負の場合は無効' do
+      goal = build(:savings_goal, current_amount: -1)
+      expect(goal).not_to be_valid
+    end
+
+    it 'current_amountがnilの場合は有効' do
+      goal = build(:savings_goal, current_amount: nil)
+      expect(goal).to be_valid
+    end
+  end
+
+  describe 'target_amountのバリデーション' do
+    it '0以下のtarget_amountは無効' do
+      goal = build(:savings_goal, target_amount: 0)
+      expect(goal).not_to be_valid
+    end
+
+    it '負のtarget_amountは無効' do
+      goal = build(:savings_goal, target_amount: -1000)
+      expect(goal).not_to be_valid
     end
   end
 end

--- a/back/spec/models/transaction_spec.rb
+++ b/back/spec/models/transaction_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe Transaction, type: :model do
   # バリデーション
   it { should validate_presence_of(:amount) }
   it { should validate_presence_of(:description) }
+  it { should validate_presence_of(:transaction_type) }
+  it { should validate_presence_of(:date) }
   it { should validate_numericality_of(:amount).is_greater_than(0) }
 
   describe 'transaction_type enum' do

--- a/front/src/app/auth/callback/page.tsx
+++ b/front/src/app/auth/callback/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, Suspense } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
+import { api } from '@/lib/api'
 
 function CallbackContent() {
   const searchParams = useSearchParams()
@@ -27,25 +28,12 @@ function CallbackContent() {
           return
         }
 
-        const getApiUrl = () => {
-          if (process.env.NODE_ENV === 'development') {
-            return process.env.NEXT_PUBLIC_DEV_URL;
-          }
-          return process.env.NEXT_PUBLIC_API_URL;
-        };
-
         // バックエンドにコードを送信してトークンを取得
-        const response = await fetch(`${getApiUrl()}/api/v1/auth/google/callback`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ code }),
-        })
+        const data = await api.auth.googleCallback(code)
 
-        if (response.ok) {
-          const { token } = await response.json()
-          localStorage.setItem('authToken', token)
+        if (data?.token) {
+          localStorage.setItem('authToken', data.token)
+          localStorage.setItem('isLoggedIn', 'true')
           setStatus('success')
           setMessage('ログインしました。リダイレクトしています...')
           setTimeout(() => {

--- a/front/src/app/board/page.tsx
+++ b/front/src/app/board/page.tsx
@@ -19,6 +19,8 @@ import { ja } from "date-fns/locale"
 import { MessageSquare, Heart, Search, Filter, Plus, ThumbsUp, MessageCircle, MoreVertical, Edit, Trash2, Bookmark, BookmarkCheck, Send, Eye, Loader2 } from "lucide-react"
 import { toast } from "sonner"
 import { useAuth } from "@/hooks/useAuth"
+import { api } from "@/lib/api"
+import { mapApiPost, mapApiComment, type Post, type Comment } from "@/types/post"
 
 // 掲示板カテゴリー
 const BOARD_CATEGORIES = [
@@ -39,90 +41,9 @@ const SORT_OPTIONS = [
   { value: "comments", label: "コメント数順" },
 ]
 
-type Comment = {
-  id: string
-  postId: string
-  content: string
-  author: string
-  authorEmail: string
-  userId?: number
-  createdAt: string
-  likes: number
-}
-
-type Post = {
-  id: string
-  title: string
-  content: string
-  author: string
-  authorEmail: string
-  userId?: number
-  category: string[]
-  createdAt: string
-  likes: number
-  comments: number
-  views: number
-  isBookmarked?: boolean
-}
-
-type ApiPost = {
-  id: number
-  title: string
-  content: string
-  author: string
-  author_email: string
-  user_id: number
-  categories: string[]
-  likes_count: number
-  comments_count: number
-  views_count: number
-  liked_by_me: boolean
-  bookmarked_by_me: boolean
-  created_at: string
-}
-
-type ApiComment = {
-  id: number
-  post_id: number
-  content: string
-  author: string
-  author_email: string
-  user_id: number
-  likes_count: number
-  created_at: string
-}
-
-const mapApiPost = (p: ApiPost): Post => ({
-  id: String(p.id),
-  title: p.title,
-  content: p.content,
-  author: p.author || "",
-  authorEmail: p.author_email || "",
-  userId: p.user_id,
-  category: p.categories || [],
-  createdAt: p.created_at,
-  likes: p.likes_count || 0,
-  comments: p.comments_count || 0,
-  views: p.views_count || 0,
-})
-
-const mapApiComment = (c: ApiComment): Comment => ({
-  id: String(c.id),
-  postId: String(c.post_id),
-  content: c.content,
-  author: c.author || "",
-  authorEmail: c.author_email || "",
-  userId: c.user_id,
-  createdAt: c.created_at,
-  likes: c.likes_count || 0,
-})
-
 export default function BoardPage() {
   const router = useRouter()
   const { user, token, isLoading: authIsLoading, isAuthenticated } = useAuth()
-
-  const apiUrl =
-    process.env.NODE_ENV === "development" ? process.env.NEXT_PUBLIC_DEV_URL : process.env.NEXT_PUBLIC_API_URL
 
   const [posts, setPosts] = useState<Post[]>([])
   const [likedPostIds, setLikedPostIds] = useState<string[]>([])
@@ -171,21 +92,19 @@ export default function BoardPage() {
     if (!token) return
     setIsPostsLoading(true)
     try {
-      const res = await fetch(`${apiUrl}/api/v1/posts`, {
-        headers: { Authorization: `Bearer ${token}` },
-      })
-      if (!res.ok) throw new Error("投稿の取得に失敗しました")
-      const data: ApiPost[] = await res.json()
-      setPosts(data.map(mapApiPost))
-      setLikedPostIds(data.filter((p) => p.liked_by_me).map((p) => String(p.id)))
-      setBookmarkedPosts(data.filter((p) => p.bookmarked_by_me).map((p) => String(p.id)))
+      const data = await api.posts.list(token)
+      if (data) {
+        setPosts(data.map(mapApiPost))
+        setLikedPostIds(data.filter((p) => p.liked_by_me).map((p) => String(p.id)))
+        setBookmarkedPosts(data.filter((p) => p.bookmarked_by_me).map((p) => String(p.id)))
+      }
     } catch (err) {
       console.error("投稿取得エラー:", err)
       toast.error("投稿の取得に失敗しました")
     } finally {
       setIsPostsLoading(false)
     }
-  }, [token, apiUrl])
+  }, [token])
 
   useEffect(() => {
     if (isAuthenticated && token) {
@@ -199,15 +118,10 @@ export default function BoardPage() {
     const isCurrentlyLiked = likedPostIds.includes(postId)
 
     try {
-      const endpoint = isCurrentlyLiked ? "unlike" : "like"
-      const res = await fetch(`${apiUrl}/api/v1/posts/${postId}/${endpoint}`, {
-        method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
-      })
-
-      if (!res.ok) {
-        toast.error("いいねの操作に失敗しました")
-        return
+      if (isCurrentlyLiked) {
+        await api.posts.unlike(token, postId)
+      } else {
+        await api.posts.like(token, postId)
       }
       if (isCurrentlyLiked) {
         setLikedPostIds((prev) => prev.filter((id) => id !== postId))
@@ -285,25 +199,11 @@ export default function BoardPage() {
 
     try {
       if (isBookmarked) {
-        const res = await fetch(`${apiUrl}/api/v1/posts/${postId}/bookmark`, {
-          method: "DELETE",
-          headers: { Authorization: `Bearer ${token}` },
-        })
-        if (!res.ok) {
-          toast.error("ブックマークの削除に失敗しました")
-          return
-        }
+        await api.posts.unbookmark(token, postId)
         setBookmarkedPosts((prev) => prev.filter((id) => id !== postId))
         toast.success("ブックマークを削除しました")
       } else {
-        const res = await fetch(`${apiUrl}/api/v1/posts/${postId}/bookmark`, {
-          method: "POST",
-          headers: { Authorization: `Bearer ${token}` },
-        })
-        if (!res.ok) {
-          toast.error("ブックマークの追加に失敗しました")
-          return
-        }
+        await api.posts.bookmark(token, postId)
         setBookmarkedPosts((prev) => [...prev, postId])
         toast.success("ブックマークに追加しました")
       }
@@ -325,16 +225,14 @@ export default function BoardPage() {
     if (hasError || !token) return
 
     try {
-      const res = await fetch(`${apiUrl}/api/v1/posts`, {
-        method: "POST",
-        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-        body: JSON.stringify({
-          post: { title: newPostTitle, content: newPostContent, category_names: newPostCategories },
-        }),
+      const newPost = await api.posts.create(token, {
+        title: newPostTitle,
+        content: newPostContent,
+        category_names: newPostCategories,
       })
-      if (!res.ok) throw new Error()
-      const newPost: ApiPost = await res.json()
-      setPosts((prev) => [mapApiPost(newPost), ...prev])
+      if (newPost) {
+        setPosts((prev) => [mapApiPost(newPost), ...prev])
+      }
       setNewPostTitle("")
       setNewPostContent("")
       setNewPostCategories([])
@@ -365,16 +263,14 @@ export default function BoardPage() {
     if (hasError) return
 
     try {
-      const res = await fetch(`${apiUrl}/api/v1/posts/${editingPost.id}`, {
-        method: "PATCH",
-        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-        body: JSON.stringify({
-          post: { title: newPostTitle, content: newPostContent, category_names: newPostCategories },
-        }),
+      const updated = await api.posts.update(token, editingPost.id, {
+        title: newPostTitle,
+        content: newPostContent,
+        category_names: newPostCategories,
       })
-      if (!res.ok) throw new Error()
-      const updated: ApiPost = await res.json()
-      setPosts((prev) => prev.map((p) => (p.id === editingPost.id ? mapApiPost(updated) : p)))
+      if (updated) {
+        setPosts((prev) => prev.map((p) => (p.id === editingPost.id ? mapApiPost(updated) : p)))
+      }
       setNewPostTitle("")
       setNewPostContent("")
       setNewPostCategories([])
@@ -392,27 +288,24 @@ export default function BoardPage() {
     setIsPostDetailDialogOpen(true)
 
     // 閲覧数を増加
-    try {
-      await fetch(`${apiUrl}/api/v1/posts/${post.id}/increment_views`, {
-        method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
-      })
-      setPosts((prev) => prev.map((p) => (p.id === post.id ? { ...p, views: p.views + 1 } : p)))
-    } catch { /* 閲覧数エラーは無視 */ }
+    if (token) {
+      try {
+        await api.posts.incrementViews(token, post.id)
+        setPosts((prev) => prev.map((p) => (p.id === post.id ? { ...p, views: p.views + 1 } : p)))
+      } catch { /* 閲覧数エラーは無視 */ }
 
-    // コメント取得
-    try {
-      const res = await fetch(`${apiUrl}/api/v1/posts/${post.id}/comments`, {
-        headers: { Authorization: `Bearer ${token}` },
-      })
-      if (!res.ok) return
-      const data: ApiComment[] = await res.json()
-      setComments((prev) => [
-        ...prev.filter((c) => c.postId !== post.id),
-        ...data.map(mapApiComment),
-      ])
-    } catch (err) {
-      console.error("コメント取得エラー:", err)
+      // コメント取得
+      try {
+        const data = await api.posts.comments.list(token, post.id)
+        if (data) {
+          setComments((prev) => [
+            ...prev.filter((c) => c.postId !== post.id),
+            ...data.map(mapApiComment),
+          ])
+        }
+      } catch (err) {
+        console.error("コメント取得エラー:", err)
+      }
     }
   }
 
@@ -424,17 +317,13 @@ export default function BoardPage() {
     }
 
     try {
-      const res = await fetch(`${apiUrl}/api/v1/posts/${selectedPost.id}/comments`, {
-        method: "POST",
-        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-        body: JSON.stringify({ comment: { content: newCommentContent } }),
-      })
-      if (!res.ok) throw new Error()
-      const newComment: ApiComment = await res.json()
-      setComments((prev) => [...prev, mapApiComment(newComment)])
-      setPosts((prev) =>
-        prev.map((p) => (p.id === selectedPost.id ? { ...p, comments: p.comments + 1 } : p))
-      )
+      const newComment = await api.posts.comments.create(token, selectedPost.id, newCommentContent)
+      if (newComment) {
+        setComments((prev) => [...prev, mapApiComment(newComment)])
+        setPosts((prev) =>
+          prev.map((p) => (p.id === selectedPost.id ? { ...p, comments: p.comments + 1 } : p))
+        )
+      }
       setNewCommentContent("")
       toast.success("コメントを投稿しました")
     } catch {
@@ -448,11 +337,11 @@ export default function BoardPage() {
     const isCurrentlyLiked = likedCommentIds.includes(commentId)
 
     try {
-      const endpoint = isCurrentlyLiked ? "unlike" : "like"
-      await fetch(`${apiUrl}/api/v1/posts/${selectedPost.id}/comments/${commentId}/${endpoint}`, {
-        method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
-      })
+      if (isCurrentlyLiked) {
+        await api.posts.comments.unlike(token, selectedPost.id, commentId)
+      } else {
+        await api.posts.comments.like(token, selectedPost.id, commentId)
+      }
 
       if (isCurrentlyLiked) {
         setLikedCommentIds((prev) => prev.filter((id) => id !== commentId))
@@ -483,15 +372,7 @@ export default function BoardPage() {
     if (!deletingPostId || !token) return
 
     try {
-      const res = await fetch(`${apiUrl}/api/v1/posts/${deletingPostId}`, {
-        method: "DELETE",
-        headers: { Authorization: `Bearer ${token}` },
-      })
-
-      if (!res.ok) {
-        toast.error("投稿の削除に失敗しました")
-        return
-      }
+      await api.posts.delete(token, deletingPostId)
       setPosts((prev) => prev.filter((post) => post.id !== deletingPostId))
       setDeletingPostId(null)
       setIsDeleteDialogOpen(false)

--- a/front/src/app/collection/page.tsx
+++ b/front/src/app/collection/page.tsx
@@ -9,25 +9,9 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import Image from "next/image"
 import { cn } from "@/lib/utils"
 import { LockIcon, UnlockIcon, AlertTriangle, Trophy } from 'lucide-react';
-
-// 実績の型定義 (Rails APIのレスポンスに合わせて調整)
-interface Achievement {
-  id: number | string;
-  original_achievement_id: string; // Rails APIから
-  title: string;
-  description: string;
-  category: string; // 文字列として受け取る
-  tier: string; // 文字列として受け取る
-  unlocked: boolean; // Rails APIでは `unlocked`
-  progress: number;
-  progress_percentage: number; // Rails APIから
-  progress_target: number; // Rails APIから
-  image_url?: string; // Rails APIでは `image_url`
-  reward: string;
-  created_at: string; // Rails APIから
-  updated_at: string; // Rails APIから
-  unlocked_at?: string | null; // Rails APIから
-}
+import { useAuth } from "@/hooks/useAuth"
+import { api } from "@/lib/api"
+import type { Achievement, AchievementSummary } from "@/types/achievement"
 
 // カテゴリ表示用の日本語マッピング
 const categoryLabels: Record<string, string> = {
@@ -46,38 +30,23 @@ const tierLabels: Record<string, string> = {
   platinum: 'プラチナ'
 };
 
-// APIレスポンス全体の型 (必要であれば)
-interface AchievementsApiResponse {
-  achievements: Achievement[];
-  summary: {
-    total_achievements: number;
-    unlocked_achievements: number;
-    progress_by_category: Record<string, { total: number; unlocked: number; progress_percentage: number }>;
-  };
-}
-
 export default function CollectionPage() {
   const router = useRouter();
+  const { token, isLoading: authIsLoading, isAuthenticated } = useAuth();
   // 実績関連
   const [achievements, setAchievements] = useState<Achievement[]>([])
   const [filteredAchievements, setFilteredAchievements] = useState<Achievement[]>([]);
   const [activeTab, setActiveTab] = useState("all");
   const [loadingAchievements, setLoadingAchievements] = useState(true);
   const [errorAchievements, setErrorAchievements] = useState<string | null>(null);
-  const [achievementSummary, setAchievementSummary] = useState<AchievementsApiResponse['summary'] | null>(null);
+  const [achievementSummary, setAchievementSummary] = useState<AchievementSummary | null>(null);
 
-
-  // ログイン状態を確認
+  // 認証チェック
   useEffect(() => {
-    // ログイン状態をチェック
-    const isLoggedIn = localStorage.getItem("isLoggedIn") === "true"
-
-    if (!isLoggedIn) {
-      // ログインしていない場合
+    if (!authIsLoading && !isAuthenticated) {
       router.push("/login")
-      return
     }
-  }, [router])
+  }, [authIsLoading, isAuthenticated, router])
 
   /*
       // 隠し実績
@@ -101,50 +70,29 @@ export default function CollectionPage() {
 */
 
   useEffect(() => {
+    if (!isAuthenticated || !token) return
+
     // 実績データを取得
     const fetchAchievements = async () => {
       setLoadingAchievements(true);
       setErrorAchievements(null);
       try {
-        // JWTトークンを取得（正しいキー名を使用）
-        const token = localStorage.getItem("authToken");
-        
-        const getApiUrl = () => {
-          if (process.env.NODE_ENV === 'development') {
-            return process.env.NEXT_PUBLIC_DEV_URL;
-          }
-          return process.env.NEXT_PUBLIC_API_URL;
-        };
-        
-        // Rails APIから取得
-        const response = await fetch(`${getApiUrl()}/api/v1/achievements`, {
-          method: 'GET',
-          headers: {
-            'Content-Type': 'application/json',
-            ...(token && { 'Authorization': `Bearer ${token}` })
-          },
-          credentials: 'include', // CSRFトークンを含めるために必要
-        }); // Rails側の実績APIエンドポイント
-
-        if (!response.ok) {
-          throw new Error(`実績データの取得に失敗しました。ステータス: ${response.status}`);
+        const data = await api.achievements.list(token);
+        if (data) {
+          setAchievements(data.achievements || []);
+          setFilteredAchievements(data.achievements || []);
+          setAchievementSummary(data.summary || null);
         }
-
-        const data = await response.json();
-        //APIのデータ構造に合わせて実績データを設定
-        setAchievements(data.achievements || []);
-        setFilteredAchievements(data.achievements || []);
-        setAchievementSummary(data.summary || null);
-
-      } catch (err: any) {
-        setErrorAchievements(err.message);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "実績データの取得に失敗しました"
+        setErrorAchievements(message);
         console.error("Error fetching achievements:", err);
       } finally {
         setLoadingAchievements(false);
       }
     };
     fetchAchievements();
-  }, []);
+  }, [isAuthenticated, token]);
 
   const filterAchievements = (category: string) => {
     setActiveTab(category);

--- a/front/src/app/contact/page.tsx
+++ b/front/src/app/contact/page.tsx
@@ -13,9 +13,12 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { toast } from "sonner"
 import { Loader2 } from "lucide-react"
 import { contactSchema, type ContactFormValues } from "@/lib/schemas/auth"
+import { api } from "@/lib/api"
+import { useAuth } from "@/hooks/useAuth"
 
 export default function ContactPage() {
   const router = useRouter()
+  const { user, isAuthenticated } = useAuth()
 
   const {
     register,
@@ -31,33 +34,14 @@ export default function ContactPage() {
 
   // ログイン中のメールアドレスを自動入力
   useEffect(() => {
-    const isLoggedIn = localStorage.getItem("isLoggedIn") === "true"
-    if (isLoggedIn) {
-      const userEmail = localStorage.getItem("currentUserEmail")
-      if (userEmail) {
-        setValue("email", userEmail)
-      }
+    if (isAuthenticated && user?.email) {
+      setValue("email", user.email)
     }
-  }, [setValue])
+  }, [isAuthenticated, user, setValue])
 
   const onSubmit = async (data: ContactFormValues) => {
     try {
-      const apiUrl =
-        process.env.NODE_ENV === "development"
-          ? process.env.NEXT_PUBLIC_DEV_URL
-          : process.env.NEXT_PUBLIC_API_URL
-
-      const res = await fetch(`${apiUrl}/api/v1/contacts`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ contact: data }),
-      })
-
-      if (!res.ok) {
-        const errorData = await res.json()
-        throw new Error(errorData.errors?.join(", ") || "エラーが発生しました")
-      }
-
+      await api.contacts.send(data)
       toast.success("送信完了", { description: "お問い合わせを受け付けました。回答をお待ちください。" })
       reset()
       router.push("/")

--- a/front/src/app/dashboard/page.tsx
+++ b/front/src/app/dashboard/page.tsx
@@ -52,24 +52,8 @@ import {
 import { cn } from "@/lib/utils"
 import { useRouter } from "next/navigation"
 import { useAuth } from "@/hooks/useAuth"
-
-type Transaction = {
-  id: string
-  amount: number
-  type: "income" | "expense"
-  category: string
-  description: string
-  date: string
-}
-
-type ApiTransaction = {
-  id: number
-  amount: string | number
-  transaction_type: string
-  category: string
-  description: string | null
-  date: string
-}
+import { api } from "@/lib/api"
+import { type Transaction, mapApiTransaction } from "@/types/transaction"
 
 const EXPENSE_CATEGORIES = [
   { value: "food", label: "食費", icon: <Coffee className="h-4 w-4" /> },
@@ -92,15 +76,6 @@ const INCOME_CATEGORIES = [
   { value: "other", label: "その他", icon: <DollarSign className="h-4 w-4" /> },
 ]
 
-const mapApiTransaction = (t: ApiTransaction): Transaction => ({
-  id: String(t.id),
-  amount: Number(t.amount),
-  type: t.transaction_type as "income" | "expense",
-  category: t.category,
-  description: t.description || "",
-  date: t.date ? t.date.split("T")[0] : "",
-})
-
 export default function DashboardPage() {
   const [transactions, setTransactions] = useState<Transaction[]>([])
   const [amount, setAmount] = useState("")
@@ -116,9 +91,6 @@ export default function DashboardPage() {
   const router = useRouter()
   const { user, token, isLoading: authIsLoading, isAuthenticated } = useAuth()
 
-  const apiUrl =
-    process.env.NODE_ENV === "development" ? process.env.NEXT_PUBLIC_DEV_URL : process.env.NEXT_PUBLIC_API_URL
-
   useEffect(() => {
     if (!authIsLoading && !isAuthenticated) {
       router.push("/login")
@@ -132,12 +104,10 @@ export default function DashboardPage() {
     const fetchTransactions = async () => {
       setIsDataLoading(true)
       try {
-        const res = await fetch(`${apiUrl}/api/v1/transactions`, {
-          headers: { Authorization: `Bearer ${token}` },
-        })
-        if (!res.ok) throw new Error("取引データの取得に失敗しました")
-        const data = await res.json()
-        setTransactions((data.transactions as ApiTransaction[]).map(mapApiTransaction))
+        const data = await api.transactions.list(token)
+        if (data) {
+          setTransactions(data.transactions.map(mapApiTransaction))
+        }
       } catch (err) {
         console.error("取引データ取得エラー:", err)
       } finally {
@@ -146,7 +116,7 @@ export default function DashboardPage() {
     }
 
     fetchTransactions()
-  }, [isAuthenticated, token, apiUrl])
+  }, [isAuthenticated, token])
 
   // Update otter mood based on financial health
   useEffect(() => {
@@ -202,25 +172,16 @@ export default function DashboardPage() {
     const numericAmount = Number.parseFloat(amount.replace(/,/g, ""))
 
     try {
-      const res = await fetch(`${apiUrl}/api/v1/transactions`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          transaction: {
-            amount: numericAmount,
-            transaction_type: type,
-            category,
-            description,
-            date: format(date, "yyyy-MM-dd"),
-          },
-        }),
+      const newTx = await api.transactions.create(token, {
+        amount: numericAmount,
+        transaction_type: type,
+        category,
+        description,
+        date: format(date, "yyyy-MM-dd"),
       })
-      if (!res.ok) throw new Error("取引の登録に失敗しました")
-      const newTx: ApiTransaction = await res.json()
-      setTransactions((prev) => [...prev, mapApiTransaction(newTx)])
+      if (newTx) {
+        setTransactions((prev) => [...prev, mapApiTransaction(newTx)])
+      }
       setAmount("")
       setAmountError(null)
       setDescription("")
@@ -233,13 +194,7 @@ export default function DashboardPage() {
   const deleteTransaction = async (id: string) => {
     if (!token) return
     try {
-      const res = await fetch(`${apiUrl}/api/v1/transactions/${id}`, {
-        method: "DELETE",
-        headers: { Authorization: `Bearer ${token}` },
-      })
-      if (!res.ok) {
-        throw new Error("取引の削除に失敗しました")
-      }
+      await api.transactions.delete(token, id)
       setTransactions((prev) => prev.filter((t) => t.id !== id))
     } catch (err) {
       console.error("取引削除エラー:", err)

--- a/front/src/app/login/page.tsx
+++ b/front/src/app/login/page.tsx
@@ -14,6 +14,8 @@ import { AlertCircle, Loader2 } from "lucide-react"
 import Image from "next/image"
 import { useState } from "react"
 import { loginSchema, type LoginFormValues } from "@/lib/schemas/auth"
+import { api } from "@/lib/api"
+import { getBaseUrl } from "@/lib/api-client"
 
 export default function LoginPage() {
   const [apiError, setApiError] = useState<string | null>(null)
@@ -28,40 +30,13 @@ export default function LoginPage() {
     resolver: zodResolver(loginSchema),
   })
 
-  const getApiUrl = () => {
-    if (process.env.NODE_ENV === "development") {
-      return process.env.NEXT_PUBLIC_DEV_URL
-    }
-    return process.env.NEXT_PUBLIC_API_URL
-  }
-
   const onSubmit = async (data: LoginFormValues) => {
     setApiError(null)
 
     try {
-      const response = await fetch(`${getApiUrl()}/api/v1/sessions`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email: data.email, password: data.password }),
-      })
+      const responseData = await api.auth.login(data.email, data.password)
 
-      if (!response.ok) {
-        const errorData = await response.json()
-        switch (response.status) {
-          case 401:
-            throw new Error("メールアドレスまたはパスワードが正しくありません")
-          case 403:
-            throw new Error("アカウントがロックされています")
-          case 404:
-            throw new Error("アカウントが見つかりません")
-          default:
-            throw new Error(errorData.error || "ログインに失敗しました")
-        }
-      }
-
-      const responseData = await response.json()
-
-      if (!responseData.token) {
+      if (!responseData?.token) {
         throw new Error("認証トークンの取得に失敗しました")
       }
 
@@ -86,7 +61,7 @@ export default function LoginPage() {
     setIsGoogleLoading(true)
 
     try {
-      window.location.href = `${getApiUrl()}/api/v1/auth/google`
+      window.location.href = `${getBaseUrl()}/api/v1/auth/google`
     } catch (error) {
       console.error("Google認証エラー:", error)
       setApiError("Google認証中にエラーが発生しました。後でもう一度お試しください。")

--- a/front/src/app/register/page.tsx
+++ b/front/src/app/register/page.tsx
@@ -12,8 +12,8 @@ import { Label } from "@/components/ui/label"
 import { toast } from "sonner"
 import { Loader2, Mail, Lock, User, AlertCircle } from "lucide-react"
 import { Alert, AlertDescription } from "@/components/ui/alert"
-import { parseApiError } from "@/lib/api-error"
 import { registerSchema, type RegisterFormValues } from "@/lib/schemas/auth"
+import { api } from "@/lib/api"
 
 export default function RegisterPage() {
   const router = useRouter()
@@ -27,48 +27,23 @@ export default function RegisterPage() {
     resolver: zodResolver(registerSchema),
   })
 
-  const getApiUrl = () => {
-    if (process.env.NODE_ENV === "development") {
-      return process.env.NEXT_PUBLIC_DEV_URL
-    }
-    return process.env.NEXT_PUBLIC_API_URL
-  }
-
   const onSubmit = async (data: RegisterFormValues) => {
     setApiError(null)
 
     try {
-      const response = await fetch(`${getApiUrl()}/api/v1/users`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          user: {
-            username: data.username,
-            email: data.email,
-            password: data.password,
-            password_confirmation: data.confirmPassword,
-          },
-        }),
+      const responseData = await api.auth.register({
+        username: data.username,
+        email: data.email,
+        password: data.password,
+        password_confirmation: data.confirmPassword,
       })
-
-      if (!response.ok) {
-        let errorData: unknown
-        try {
-          errorData = await response.json()
-        } catch {
-          errorData = null
-        }
-        throw new Error(parseApiError(errorData, "登録に失敗しました。"))
-      }
-
-      const responseData = await response.json()
 
       localStorage.setItem("isLoggedIn", "true")
       localStorage.setItem("currentUserEmail", data.email)
-      if (responseData.token) {
+      if (responseData?.token) {
         localStorage.setItem("authToken", responseData.token)
       }
-      if (responseData.refresh_token) {
+      if (responseData?.refresh_token) {
         localStorage.setItem("refreshToken", responseData.refresh_token)
       }
       localStorage.setItem("tutorialSeen", "false")

--- a/front/src/app/reset-password/[token]/page.tsx
+++ b/front/src/app/reset-password/[token]/page.tsx
@@ -11,6 +11,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { AlertCircle, CheckCircle2, Loader2 } from "lucide-react"
 import { resetPasswordSchema, type ResetPasswordFormValues } from "@/lib/schemas/auth"
+import { api } from "@/lib/api"
 
 export default function ResetPasswordPage() {
   const { token } = useParams<{ token: string }>()
@@ -26,34 +27,17 @@ export default function ResetPasswordPage() {
     resolver: zodResolver(resetPasswordSchema),
   })
 
-  const getApiUrl = () => {
-    if (process.env.NODE_ENV === "development") {
-      return process.env.NEXT_PUBLIC_DEV_URL
-    }
-    return process.env.NEXT_PUBLIC_API_URL
-  }
-
   const onSubmit = async (data: ResetPasswordFormValues) => {
     setApiError("")
     setSuccessMessage("")
 
     try {
-      const response = await fetch(`${getApiUrl()}/api/v1/auth/reset-password`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ token, password: data.password }),
-      })
-
-      if (response.ok) {
-        setSuccessMessage("パスワードがリセットされました。ログインページにリダイレクトします。")
-        setTimeout(() => router.push("/login"), 3000)
-      } else {
-        const errorData = await response.json()
-        setApiError(errorData.message || "パスワードのリセットに失敗しました")
-      }
+      await api.auth.resetPassword(token, data.password)
+      setSuccessMessage("パスワードがリセットされました。ログインページにリダイレクトします。")
+      setTimeout(() => router.push("/login"), 3000)
     } catch (err) {
       console.error("Password reset error:", err)
-      setApiError("ネットワークエラーが発生しました")
+      setApiError(err instanceof Error ? err.message : "パスワードのリセットに失敗しました")
     }
   }
 

--- a/front/src/lib/api.ts
+++ b/front/src/lib/api.ts
@@ -1,0 +1,186 @@
+import { apiRequest, publicApiRequest } from '@/lib/api-client'
+import type { ApiTransaction } from '@/types/transaction'
+import type { ApiPost, ApiComment } from '@/types/post'
+import type { AchievementResponse } from '@/types/achievement'
+
+// ========== 型定義 ==========
+
+type LoginResponse = {
+  token: string
+  refresh_token?: string
+}
+
+type RegisterParams = {
+  username: string
+  email: string
+  password: string
+  password_confirmation: string
+}
+
+type CreateTransactionParams = {
+  amount: number
+  transaction_type: "income" | "expense"
+  category: string
+  description: string
+  date: string
+}
+
+type CreatePostParams = {
+  title: string
+  content: string
+  category_names: string[]
+}
+
+type ContactParams = {
+  name: string
+  email: string
+  subject: string
+  message: string
+}
+
+// ========== API ==========
+
+export const api = {
+  /** 認証 */
+  auth: {
+    /** ログイン */
+    login: (email: string, password: string) =>
+      publicApiRequest<LoginResponse>('/sessions', {
+        method: 'POST',
+        body: { email, password },
+      }),
+
+    /** ユーザー登録 */
+    register: (params: RegisterParams) =>
+      publicApiRequest<LoginResponse>('/users', {
+        method: 'POST',
+        body: { user: params },
+      }),
+
+    /** Google OAuth コールバック */
+    googleCallback: (code: string) =>
+      publicApiRequest<{ token: string }>('/auth/google/callback', {
+        method: 'POST',
+        body: { code },
+      }),
+
+    /** パスワードリセット */
+    resetPassword: (token: string, password: string) =>
+      publicApiRequest<void>('/auth/reset-password', {
+        method: 'POST',
+        body: { token, password },
+      }),
+  },
+
+  /** 取引 */
+  transactions: {
+    /** 取引一覧を取得する */
+    list: (token: string) =>
+      apiRequest<{ transactions: ApiTransaction[] }>('/transactions', { token }),
+
+    /** 取引を作成する */
+    create: (token: string, params: CreateTransactionParams) =>
+      apiRequest<ApiTransaction>('/transactions', {
+        method: 'POST',
+        token,
+        body: { transaction: params },
+      }),
+
+    /** 取引を削除する */
+    delete: (token: string, id: string) =>
+      apiRequest<void>(`/transactions/${id}`, { method: 'DELETE', token }),
+  },
+
+  /** 実績 */
+  achievements: {
+    /** 実績一覧を取得する */
+    list: (token: string) =>
+      apiRequest<AchievementResponse>('/achievements', { token }),
+  },
+
+  /** お問い合わせ */
+  contacts: {
+    /** お問い合わせを送信する */
+    send: (params: ContactParams) =>
+      publicApiRequest<void>('/contacts', {
+        method: 'POST',
+        body: { contact: params },
+      }),
+  },
+
+  /** 投稿 */
+  posts: {
+    /** 投稿一覧を取得する */
+    list: (token: string) =>
+      apiRequest<ApiPost[]>('/posts', { token }),
+
+    /** 投稿を作成する */
+    create: (token: string, params: CreatePostParams) =>
+      apiRequest<ApiPost>('/posts', {
+        method: 'POST',
+        token,
+        body: { post: params },
+      }),
+
+    /** 投稿を更新する */
+    update: (token: string, id: string, params: CreatePostParams) =>
+      apiRequest<ApiPost>(`/posts/${id}`, {
+        method: 'PATCH',
+        token,
+        body: { post: params },
+      }),
+
+    /** 投稿を削除する */
+    delete: (token: string, id: string) =>
+      apiRequest<void>(`/posts/${id}`, { method: 'DELETE', token }),
+
+    /** 投稿にいいねする */
+    like: (token: string, id: string) =>
+      apiRequest<void>(`/posts/${id}/like`, { method: 'POST', token }),
+
+    /** 投稿のいいねを取り消す */
+    unlike: (token: string, id: string) =>
+      apiRequest<void>(`/posts/${id}/unlike`, { method: 'POST', token }),
+
+    /** 投稿をブックマークする */
+    bookmark: (token: string, id: string) =>
+      apiRequest<void>(`/posts/${id}/bookmark`, { method: 'POST', token }),
+
+    /** 投稿のブックマークを削除する */
+    unbookmark: (token: string, id: string) =>
+      apiRequest<void>(`/posts/${id}/bookmark`, { method: 'DELETE', token }),
+
+    /** 閲覧数を増加する */
+    incrementViews: (token: string, id: string) =>
+      apiRequest<void>(`/posts/${id}/increment_views`, { method: 'POST', token }),
+
+    /** コメント */
+    comments: {
+      /** コメント一覧を取得する */
+      list: (token: string, postId: string) =>
+        apiRequest<ApiComment[]>(`/posts/${postId}/comments`, { token }),
+
+      /** コメントを投稿する */
+      create: (token: string, postId: string, content: string) =>
+        apiRequest<ApiComment>(`/posts/${postId}/comments`, {
+          method: 'POST',
+          token,
+          body: { comment: { content } },
+        }),
+
+      /** コメントにいいねする */
+      like: (token: string, postId: string, commentId: string) =>
+        apiRequest<void>(`/posts/${postId}/comments/${commentId}/like`, {
+          method: 'POST',
+          token,
+        }),
+
+      /** コメントのいいねを取り消す */
+      unlike: (token: string, postId: string, commentId: string) =>
+        apiRequest<void>(`/posts/${postId}/comments/${commentId}/unlike`, {
+          method: 'POST',
+          token,
+        }),
+    },
+  },
+}


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要

issue#157 の対応。SavingsGoal と Transaction モデルに不足していたバリデーションを追加する。

## 詳細な変更点

- [ ] `SavingsGoal` モデルにバリデーションを追加
  - `title`: presence
  - `target_amount`: presence + `greater_than: 0`
  - `deadline`: presence
  - `current_amount`: `greater_than_or_equal_to: 0`（nil 許可）
  - カスタムバリデーション: `current_amount <= target_amount`
- [ ] `Transaction` モデルにバリデーションを追加
  - `transaction_type`: presence
  - `date`: presence
- [ ] 各モデルスペックにバリデーションテストを追加（25例題、0失敗）

## 修正された問題

fix #157

<!-- I want to review in Japanese. -->