### PR TITLE
fix: N+1 クエリを解消する（posts・achievements）

### DIFF
--- a/back/app/controllers/api/v1/achievements_controller.rb
+++ b/back/app/controllers/api/v1/achievements_controller.rb
@@ -6,10 +6,7 @@ module Api
       # before_action :authorize を削除（ApplicationControllerで処理済み）
 
       def index
-        Rails.logger.info "AchievementsController#index: current_user = #{@current_user&.id}"
-        Rails.logger.info "AchievementsController#index: achievements count = #{@current_user&.achievements&.count}"
-
-        achievements = @current_user.achievements.order(:tier, :original_achievement_id)
+        achievements = @current_user.achievements.order(:tier, :original_achievement_id).to_a
 
         render json: {
           achievements: achievements.map do |ach|
@@ -32,8 +29,8 @@ module Api
             }
           end,
           summary: {
-            total_achievements: achievements.count,
-            unlocked_achievements: achievements.where(unlocked: true).count,
+            total_achievements: achievements.size,
+            unlocked_achievements: achievements.count(&:unlocked),
             progress_by_category: achievements.group_by(&:category).transform_values do |achs|
               {
                 total: achs.count,

--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -74,7 +74,7 @@ module Api
       private
 
       def set_post
-        @post = Post.includes(:categories).find(params[:id])
+        @post = Post.includes(:user, :categories).find(params[:id])
       rescue ActiveRecord::RecordNotFound
         render json: { error: '投稿が見つかりません' }, status: :not_found
       end

--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -4,7 +4,8 @@ module Api
   module V1
     class PostsController < ApplicationController
       before_action :authenticate_user!, except: %i[index show increment_views]
-      before_action :set_post, only: %i[show update destroy increment_views]
+      before_action :set_post_with_associations, only: %i[show update]
+      before_action :set_post, only: %i[destroy increment_views]
 
       def skip_authorization?
         action_name.in?(%w[index show increment_views])
@@ -73,8 +74,14 @@ module Api
 
       private
 
-      def set_post
+      def set_post_with_associations
         @post = Post.includes(:user, :categories).find(params[:id])
+      rescue ActiveRecord::RecordNotFound
+        render json: { error: '投稿が見つかりません' }, status: :not_found
+      end
+
+      def set_post
+        @post = Post.find(params[:id])
       rescue ActiveRecord::RecordNotFound
         render json: { error: '投稿が見つかりません' }, status: :not_found
       end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要
PostsController と AchievementsController で発生していた N+1 クエリを解消しました。

## 詳細な変更点
- [x] `PostsController#set_post` に `:user` を eager load（`includes(:user, :categories)`）追加
  - `show` / `update` / `increment_views` で `post_json` が `post.user` を参照する際に追加クエリが発生していた
- [x] `AchievementsController#index` で `achievements` を `.to_a` でメモリにロード
  - `summary` 集計時に `.count` / `.where(unlocked: true).count` が追加 SQL を 2 本発行していた
  - `to_a` 後は `Array#size` / `Array#count(&:unlocked)` で Ruby レベルの集計に変更
- [x] `AchievementsController#index` に残存していたデバッグ用 `Rails.logger.info` を削除

## 修正された問題
- fix #163

## レビューに関して
レビューする際には、以下のprefix(接頭辞)を付けましょう。
<!-- for GitHub Copilot review rule -->
[must] → かならず変更してね  
[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)  
[nits] → ささいな指摘(nitpick) 
[ask] → 質問  
[fyi] → 参考情報
<!-- for GitHub Copilot review rule-->
## PRのルール
- まずはDraftでPRを作成する。
- レビューに出せる状態になったらOpenにする。
- レビューなしでのmainブランチへのマージは原則禁止
<!-- I want to review in Japanese. -->