### PR TITLE
fix: localStorage 直接操作を useAuth 経由に変更する

### DIFF
--- a/front/src/app/login/page.tsx
+++ b/front/src/app/login/page.tsx
@@ -16,11 +16,13 @@ import { useState } from "react"
 import { loginSchema, type LoginFormValues } from "@/lib/schemas/auth"
 import { api } from "@/lib/api"
 import { getBaseUrl } from "@/lib/api-client"
+import { useAuth } from "@/hooks/useAuth"
 
 export default function LoginPage() {
   const [apiError, setApiError] = useState<string | null>(null)
   const [isGoogleLoading, setIsGoogleLoading] = useState(false)
   const router = useRouter()
+  const { login } = useAuth()
 
   const {
     register,
@@ -40,12 +42,7 @@ export default function LoginPage() {
         throw new Error("認証トークンの取得に失敗しました")
       }
 
-      localStorage.setItem("authToken", responseData.token)
-      if (responseData.refresh_token) {
-        localStorage.setItem("refreshToken", responseData.refresh_token)
-      }
-      localStorage.setItem("isLoggedIn", "true")
-      localStorage.setItem("currentUserEmail", data.email)
+      await login(responseData.token, data.email, responseData.refresh_token)
 
       toast.success("ログイン成功", { description: "ダッシュボードにリダイレクトします" })
       router.push("/dashboard")

--- a/front/src/app/register/page.tsx
+++ b/front/src/app/register/page.tsx
@@ -14,10 +14,12 @@ import { Loader2, Mail, Lock, User, AlertCircle } from "lucide-react"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { registerSchema, type RegisterFormValues } from "@/lib/schemas/auth"
 import { api } from "@/lib/api"
+import { useAuth } from "@/hooks/useAuth"
 
 export default function RegisterPage() {
   const router = useRouter()
   const [apiError, setApiError] = useState<string | null>(null)
+  const { login } = useAuth()
 
   const {
     register,
@@ -42,12 +44,7 @@ export default function RegisterPage() {
         throw new Error("認証トークンを取得できませんでした。もう一度お試しください。")
       }
 
-      localStorage.setItem("authToken", responseData.token)
-      if (responseData.refresh_token) {
-        localStorage.setItem("refreshToken", responseData.refresh_token)
-      }
-      localStorage.setItem("isLoggedIn", "true")
-      localStorage.setItem("currentUserEmail", data.email)
+      await login(responseData.token, data.email, responseData.refresh_token)
       localStorage.setItem("tutorialSeen", "false")
 
       toast.success("登録完了", { description: "アカウントが正常に作成されました。" })

--- a/front/src/components/header.tsx
+++ b/front/src/components/header.tsx
@@ -15,38 +15,24 @@ import { Sun, Moon, Menu, LogIn, LogOut, UserPlus, Home, BookOpen, MessageSquare
 import Image from "next/image"
 import { usePathname, useRouter } from 'next/navigation'
 import { useEffect, useState } from "react"
+import { useAuth } from "@/hooks/useAuth"
+
 export default function Header() {
   const { theme, setTheme } = useTheme()
   const pathname = usePathname()
   const router = useRouter()
-  const [isLoggedIn, setIsLoggedIn] = useState(false)
+  const { isAuthenticated, logout, isLoading } = useAuth()
   const [mounted, setMounted] = useState(false)
-  const logoHref = isLoggedIn ? "/dashboard" : "/";
+  const logoHref = isAuthenticated ? "/dashboard" : "/";
 
   useEffect(() => {
     setMounted(true)
-    const loggedInStatus = localStorage.getItem("isLoggedIn") === "true"
-    setIsLoggedIn(loggedInStatus)
+  }, [])
 
-    const handleStorageChange = () => {
-      const newLoggedInStatus = localStorage.getItem("isLoggedIn") === "true";
-      if (isLoggedIn !== newLoggedInStatus) {
-        setIsLoggedIn(newLoggedInStatus);
-        if (!newLoggedInStatus && (pathname === "/dashboard" || pathname === "/collection" || pathname === "/board")) {
-          router.push("/");
-        }
-      }
-    };
-    window.addEventListener('storage', handleStorageChange);
-    return () => {
-      window.removeEventListener('storage', handleStorageChange);
-    };
-  }, [isLoggedIn, pathname, router, theme])
-
-  const handleLogout = () => {
-    localStorage.removeItem("isLoggedIn");
-    setIsLoggedIn(false);
-    router.push("/");
+  const handleLogout = async () => {
+    await logout()
+    // router.push("/") は logout 内で行われるか、ここで行うかは実装による
+    // useAuth の logout 内で router.push('/login') が呼ばれるはずなので十分
   };
 
   const commonLinks = [
@@ -67,13 +53,13 @@ export default function Header() {
     ...commonLinks,
   ];
 
-  const navLinks = isLoggedIn ? loggedInLinks : loggedOutLinks;
+  const navLinks = isAuthenticated ? loggedInLinks : loggedOutLinks;
 
-  if (!mounted) {
+  if (!mounted || isLoading) {
     return (
       <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 dark:border-slate-800">
         <div className="header-container flex h-16 items-center justify-between">
-          <Link href={logoHref} className="flex items-center gap-2">
+          <Link href="/" className="flex items-center gap-2">
             <Image src="/logo.png" alt="Otter Bank Logo" width={32} height={32} className="rounded-full" />
             <span className="font-bold text-lg">Otter Bank</span>
           </Link>
@@ -110,7 +96,7 @@ export default function Header() {
               </Link>
             </Button>
           ))}
-          {isLoggedIn && (
+          {isAuthenticated && (
             <Button
               variant="ghost"
               size="sm"
@@ -143,7 +129,7 @@ export default function Header() {
                   </Link>
                 </DropdownMenuItem>
               ))}
-              {isLoggedIn && (
+              {isAuthenticated && (
                 <>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem

--- a/front/src/hooks/useAuth.ts
+++ b/front/src/hooks/useAuth.ts
@@ -1,8 +1,8 @@
-'use client';
+"use client";
 
-import { useState, useEffect } from 'react';
-import { toast } from 'sonner';
-import { useRouter } from 'next/navigation';
+import { useState, useEffect } from "react";
+import { toast } from "sonner";
+import { useRouter } from "next/navigation";
 
 interface User {
   id: number;
@@ -22,7 +22,7 @@ export const useAuth = () => {
   }, []);
 
   const getApiUrl = () => {
-    if (process.env.NODE_ENV === 'development') {
+    if (process.env.NODE_ENV === "development") {
       return process.env.NEXT_PUBLIC_DEV_URL;
     }
     return process.env.NEXT_PUBLIC_API_URL;
@@ -30,21 +30,21 @@ export const useAuth = () => {
 
   // リフレッシュトークンを使ってアクセストークンを更新する
   const refreshAccessToken = async (): Promise<string | null> => {
-    const storedRefreshToken = localStorage.getItem('refreshToken');
+    const storedRefreshToken = localStorage.getItem("refreshToken");
     if (!storedRefreshToken) return null;
 
     try {
       const response = await fetch(`${getApiUrl()}/api/v1/auth/refresh`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ refresh_token: storedRefreshToken }),
       });
 
       if (!response.ok) return null;
 
       const data = await response.json();
-      localStorage.setItem('authToken', data.token);
-      localStorage.setItem('refreshToken', data.refresh_token);
+      localStorage.setItem("authToken", data.token);
+      localStorage.setItem("refreshToken", data.refresh_token);
       return data.token as string;
     } catch {
       return null;
@@ -52,7 +52,7 @@ export const useAuth = () => {
   };
 
   const checkAuth = async () => {
-    const storedToken = localStorage.getItem('authToken');
+    const storedToken = localStorage.getItem("authToken");
 
     if (!storedToken) {
       setUser(null);
@@ -63,18 +63,18 @@ export const useAuth = () => {
 
     try {
       const response = await fetch(`${getApiUrl()}/api/v1/auth/verify`, {
-        method: 'GET',
+        method: "GET",
         headers: {
-          'Authorization': `Bearer ${storedToken}`,
-          'Content-Type': 'application/json'
-        }
+          Authorization: `Bearer ${storedToken}`,
+          "Content-Type": "application/json",
+        },
       });
 
       if (!response.ok) {
         const errorData = await response.json();
 
         // JWT期限切れの場合はリフレッシュを試みる
-        if (errorData.code === 'token_expired') {
+        if (errorData.code === "token_expired") {
           const newToken = await refreshAccessToken();
           if (newToken) {
             // リフレッシュ成功: 新しいトークンで再検証
@@ -82,25 +82,28 @@ export const useAuth = () => {
             return;
           }
           // リフレッシュ失敗: ログアウト状態に
-          throw new Error('認証期限が切れました。再度ログインしてください。');
+          throw new Error("認証期限が切れました。再度ログインしてください。");
         }
 
-        throw new Error(errorData.error || 'Token verification failed');
+        throw new Error(errorData.error || "Token verification failed");
       }
 
       const data = await response.json();
       setUser(data.user || data);
       setToken(storedToken);
-      localStorage.setItem('isLoggedIn', 'true');
+      localStorage.setItem("isLoggedIn", "true");
     } catch (error) {
-      console.error('[Auth] JWT Token verification failed:', error);
+      console.error("[Auth] JWT Token verification failed:", error);
       clearAuthStorage();
       setUser(null);
       setToken(null);
 
       // JWT期限切れ（リフレッシュ失敗含む）の場合のみトーストを表示
-      if (error instanceof Error && error.message.includes('認証期限が切れました')) {
-        toast.error('認証期限切れ', {
+      if (
+        error instanceof Error &&
+        error.message.includes("認証期限が切れました")
+      ) {
+        toast.error("認証期限切れ", {
           description: error.message,
         });
       }
@@ -113,19 +116,19 @@ export const useAuth = () => {
   const checkAuthWithToken = async (accessToken: string) => {
     try {
       const response = await fetch(`${getApiUrl()}/api/v1/auth/verify`, {
-        method: 'GET',
+        method: "GET",
         headers: {
-          'Authorization': `Bearer ${accessToken}`,
-          'Content-Type': 'application/json'
-        }
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+        },
       });
 
-      if (!response.ok) throw new Error('Token verification failed');
+      if (!response.ok) throw new Error("Token verification failed");
 
       const data = await response.json();
       setUser(data.user || data);
       setToken(accessToken);
-      localStorage.setItem('isLoggedIn', 'true');
+      localStorage.setItem("isLoggedIn", "true");
     } catch {
       clearAuthStorage();
       setUser(null);
@@ -133,11 +136,30 @@ export const useAuth = () => {
     }
   };
 
+  const loginAuth = async (
+    accessToken: string,
+    email?: string,
+    refreshToken?: string,
+  ) => {
+    localStorage.setItem("authToken", accessToken);
+    if (refreshToken) {
+      localStorage.setItem("refreshToken", refreshToken);
+    }
+    localStorage.setItem("isLoggedIn", "true");
+    if (email) {
+      localStorage.setItem("currentUserEmail", email);
+    }
+
+    setToken(accessToken);
+    // トークン情報をもとに検証・セッション状態構築
+    await checkAuthWithToken(accessToken);
+  };
+
   const clearAuthStorage = () => {
-    localStorage.removeItem('authToken');
-    localStorage.removeItem('refreshToken');
-    localStorage.removeItem('isLoggedIn');
-    localStorage.removeItem('currentUserEmail');
+    localStorage.removeItem("authToken");
+    localStorage.removeItem("refreshToken");
+    localStorage.removeItem("isLoggedIn");
+    localStorage.removeItem("currentUserEmail");
   };
 
   // 新しい関数: 認証エラーの共通処理
@@ -147,46 +169,46 @@ export const useAuth = () => {
     setUser(null);
 
     if (error instanceof Error) {
-      toast.error('認証エラー', {
+      toast.error("認証エラー", {
         description: error.message,
       });
     } else {
-      toast.error('認証エラー', {
-        description: '予期せぬエラーが発生しました',
+      toast.error("認証エラー", {
+        description: "予期せぬエラーが発生しました",
       });
     }
 
-    router.push('/login');
+    router.push("/login");
   };
 
   const logout = async () => {
     try {
-      const currentToken = localStorage.getItem('authToken');
-      const currentRefreshToken = localStorage.getItem('refreshToken');
+      const currentToken = localStorage.getItem("authToken");
+      const currentRefreshToken = localStorage.getItem("refreshToken");
 
       if (currentRefreshToken) {
         const headers: Record<string, string> = {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         };
 
         if (currentToken) {
-          headers['Authorization'] = `Bearer ${currentToken}`;
+          headers["Authorization"] = `Bearer ${currentToken}`;
         }
 
         await fetch(`${getApiUrl()}/api/v1/auth/logout`, {
-          method: 'POST',
+          method: "POST",
           headers,
           body: JSON.stringify({ refresh_token: currentRefreshToken }),
         });
       }
     } catch (error) {
-      console.error('[Auth] ログアウトエラー:', error);
+      console.error("[Auth] ログアウトエラー:", error);
     } finally {
       clearAuthStorage();
       setUser(null);
       setToken(null);
-      window.dispatchEvent(new Event('auth-state-changed'));
-      router.push('/login');
+      window.dispatchEvent(new Event("auth-state-changed"));
+      router.push("/login");
     }
   };
 
@@ -195,6 +217,7 @@ export const useAuth = () => {
     token,
     isLoading,
     isAuthenticated: !!user && !!token,
+    login: loginAuth,
     logout,
     checkAuth,
     refreshAccessToken,


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要
セキュリティ規約に従い、`localStorage` への直接操作を `useAuth` フック経由に統一しました。

## 修正された問題
- fix #229
- fix #230

## 詳細な変更点
- [x] header.tsx の localStorage アクセスを useAuth に変更
- [x] login/page.tsx の localStorage アクセスを useAuth に変更
- [x] register/page.tsx の localStorage アクセスを useAuth に変更

<!-- I want to review in Japanese. -->
