### PR TITLE
fix: ログから機密情報を削除する

### DIFF
--- a/back/app/controllers/api/v1/auth_controller.rb
+++ b/back/app/controllers/api/v1/auth_controller.rb
@@ -34,8 +34,7 @@ module Api
         error_type = params[:error] || params[:strategy] || 'unknown'
         error_message = params[:message] || params[:error_description] || 'Authentication failed'
 
-        Rails.logger.error "OAuth認証失敗: #{error_type} - #{error_message}"
-        Rails.logger.error "失敗パラメータ: #{params.inspect}"
+        Rails.logger.error "OAuth認証失敗: type=#{error_type}, message=#{error_message}, keys=#{params.keys}"
 
         # invalid_grant エラーの場合は再試行を促す
         if error_message.include?('invalid_grant') || error_message.include?('invalid_credentials')

--- a/back/app/controllers/api/v1/sessions_controller.rb
+++ b/back/app/controllers/api/v1/sessions_controller.rb
@@ -11,12 +11,9 @@ module Api
         email = params[:email] || params[:session]&.[](:email)
         password = params[:password] || params[:session]&.[](:password)
 
-        Rails.logger.info "Login attempt with email: #{email}" if Rails.env.development?
-
         user = User.find_by(email: email)
 
         if user.nil?
-          Rails.logger.info "User not found for email: #{email}" if Rails.env.development?
           render json: {
             error: 'アカウントが見つかりません',
             code: 'account_not_found'
@@ -25,12 +22,12 @@ module Api
         end
 
         # パスワード認証のデバッグログ
-        Rails.logger.info "User found: #{user.email}" if Rails.env.development?
+        Rails.logger.info "User found: #{user.id}" if Rails.env.development?
         Rails.logger.info "OAuth providers count: #{user.oauth_providers.count}" if Rails.env.development?
         Rails.logger.info "Password provided: #{password.present?}" if Rails.env.development?
 
         if user&.authenticate(password)
-          Rails.logger.info "Authentication successful for user: #{user.email}" if Rails.env.development?
+          Rails.logger.info "Authentication successful for user: #{user.id}" if Rails.env.development?
           token = JsonWebToken.encode(user_id: user.id)
           refresh_token = RefreshToken.generate_for(user)
           render json: {
@@ -41,7 +38,7 @@ module Api
             user: user.as_json(only: %i[id email username]) # 必要に応じてユーザー情報を返す
           }, status: :ok
         else
-          Rails.logger.info "Authentication failed for user: #{user.email}" if Rails.env.development?
+          Rails.logger.info "Authentication failed for user: #{user.id}" if Rails.env.development?
           render json: {
             error: 'メールアドレスまたはパスワードが無効です',
             code: 'invalid_credentials'


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要
* ログからメールアドレスや `params.inspect` などの機密情報が出力されないように修正しました。
* セキュリティ規約に従い、`user.id` や `params.keys` を代わりに使用するようにリファクタリングしています。

## 詳細な変更点
- [x] `back/app/controllers/api/v1/sessions_controller.rb`: `user.email` の代わりに `user.id` をログ出力へ変更
- [x] `back/app/controllers/api/v1/auth_controller.rb`: `params.inspect` の代わりに `params.keys` をログ出力へ変更

## 修正された問題
* fix #222
* fix #221
<!-- I want to review in Japanese. -->
