### PR TITLE
fix: oauth_providers テーブルに (provider, uid) の一意インデックスを追加する

### DIFF
--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -77,12 +77,14 @@ class User < ApplicationRecord
       user.save!(validate: false)
     end
 
-    # OAuthプロバイダーの関連付けを作成（重複チェック）
-    unless user.oauth_providers.exists?(provider: auth.provider, uid: auth.uid)
-      user.oauth_providers.create!(
+    # OAuthプロバイダーの関連付けを作成
+    begin
+      user.oauth_providers.find_or_create_by!(
         provider: auth.provider,
         uid: auth.uid
       )
+    rescue ActiveRecord::RecordNotUnique
+      retry
     end
 
     user

--- a/back/db/migrate/20260320000000_add_unique_index_to_oauth_providers.rb
+++ b/back/db/migrate/20260320000000_add_unique_index_to_oauth_providers.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToOauthProviders < ActiveRecord::Migration[7.1]
+  def change
+    add_index :oauth_providers, [:provider, :uid], unique: true
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -95,6 +95,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_15_012647) do
     t.string "uid"
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
+    t.index ["provider", "uid"], name: "index_oauth_providers_on_provider_and_uid", unique: true
     t.index ["user_id"], name: "index_oauth_providers_on_user_id"
   end
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要
OAuthのプロバイダー情報が不整合を引き起こさないよう、`oauth_providers` テーブルに `(provider, uid)` の一意制約（ユニークインデックス）を追加しました。

## 詳細な変更点
- [x] マイグレーションファイルを作成し、`oauth_providers` テーブルの `provider, uid` にユニークインデックスを追加
- [x] `User.find_or_create_from_oauth` 処理で、レースコンディション時の `ActiveRecord::RecordNotUnique` を rescue しリトライするよう改修

## 修正された問題
* fix #224
<!-- I want to review in Japanese. -->
