### PR TITLE
fix: ゲストログイン時にリフレッシュトークンを発行する

### DIFF
--- a/back/app/controllers/api/v1/guest_sessions_controller.rb
+++ b/back/app/controllers/api/v1/guest_sessions_controller.rb
@@ -12,11 +12,13 @@ module Api
         user = User.guest
 
         token = JsonWebToken.encode(user_id: user.id)
+        refresh_token = RefreshToken.generate_for(user)
 
         render json: {
           logged_in: true,
           user: user.as_json(except: [:password_digest]),
-          token: token
+          token: token,
+          refresh_token: refresh_token.token
         }
       end
     end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要
ゲストログイン時にリフレッシュトークンが発行されず、トークン期限切れ後に再認証できない問題を修正しました。

## 詳細な変更点
- [x] `GuestSessionsController#create` にて `RefreshToken.generate_for(user)` を呼び出し、レスポンスに含めるように修正

## 修正された問題
* fix #223
<!-- I want to review in Japanese. -->
