### PR TITLE
fix: UsersController#destroy アクションを実装する

### DIFF
--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -44,6 +44,11 @@ module Api
         end
       end
 
+      def destroy
+        @current_user.destroy
+        head :no_content
+      end
+
       private
 
       def user_params

--- a/back/spec/requests/api/v1/users_spec.rb
+++ b/back/spec/requests/api/v1/users_spec.rb
@@ -61,4 +61,17 @@ RSpec.describe 'Api::V1::Users', type: :request do
       expect(response).to have_http_status(:unauthorized)
     end
   end
+
+  describe 'DELETE /api/v1/user' do
+    it '自身のアカウントを削除できる' do
+      delete '/api/v1/user', headers: headers
+      expect(response).to have_http_status(:no_content)
+      expect(User.exists?(user.id)).to be false
+    end
+
+    it '未認証ではアクセスできない' do
+      delete '/api/v1/user'
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
 end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要
`config/routes.rb` に `DELETE /api/v1/user` のルーティングが定義されているものの、コントローラーに該当アクションが存在しなかった問題を修正しました。

## 詳細な変更点
- [x] `UsersController#destroy` アクションを実装（リソースの削除後、HTTP 204 No Content を返却）
- [x] RSpec のリクエストスペックにアカウント削除のテストを追加

## 修正された問題
* fix #219
<!-- I want to review in Japanese. -->
