### PR TITLE
chore: 主要ルートページに loading.tsx・error.tsx を追加する

### DIFF
--- a/front/src/app/board/error.tsx
+++ b/front/src/app/board/error.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import { useEffect } from "react"
+import { Button } from "@/components/ui/button"
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center gap-4">
+      <h2 className="text-xl font-semibold">エラーが発生しました</h2>
+      <p className="text-muted-foreground">{error.message || "予期せぬエラーが発生しました"}</p>
+      <Button onClick={reset}>再試行</Button>
+    </div>
+  )
+}

--- a/front/src/app/board/loading.tsx
+++ b/front/src/app/board/loading.tsx
@@ -1,0 +1,9 @@
+import { Loader2 } from "lucide-react"
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <Loader2 className="h-12 w-12 animate-spin text-blue-600" />
+    </div>
+  )
+}

--- a/front/src/app/collection/error.tsx
+++ b/front/src/app/collection/error.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import { useEffect } from "react"
+import { Button } from "@/components/ui/button"
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center gap-4">
+      <h2 className="text-xl font-semibold">エラーが発生しました</h2>
+      <p className="text-muted-foreground">{error.message || "予期せぬエラーが発生しました"}</p>
+      <Button onClick={reset}>再試行</Button>
+    </div>
+  )
+}

--- a/front/src/app/collection/loading.tsx
+++ b/front/src/app/collection/loading.tsx
@@ -1,0 +1,9 @@
+import { Loader2 } from "lucide-react"
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <Loader2 className="h-12 w-12 animate-spin text-blue-600" />
+    </div>
+  )
+}

--- a/front/src/app/dashboard/error.tsx
+++ b/front/src/app/dashboard/error.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import { useEffect } from "react"
+import { Button } from "@/components/ui/button"
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center gap-4">
+      <h2 className="text-xl font-semibold">エラーが発生しました</h2>
+      <p className="text-muted-foreground">{error.message || "予期せぬエラーが発生しました"}</p>
+      <Button onClick={reset}>再試行</Button>
+    </div>
+  )
+}

--- a/front/src/app/dashboard/loading.tsx
+++ b/front/src/app/dashboard/loading.tsx
@@ -1,0 +1,9 @@
+import { Loader2 } from "lucide-react"
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <Loader2 className="h-12 w-12 animate-spin text-blue-600" />
+    </div>
+  )
+}


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要
Next.js のルートレベルのローディング・エラーハンドリングファイルが主要ページに存在しなかったため追加する。

## 詳細な変更点
- [x] `front/src/app/board/loading.tsx` を追加
- [x] `front/src/app/board/error.tsx` を追加
- [x] `front/src/app/dashboard/loading.tsx` を追加
- [x] `front/src/app/dashboard/error.tsx` を追加
- [x] `front/src/app/collection/loading.tsx` を追加
- [x] `front/src/app/collection/error.tsx` を追加

`loading.tsx`: `Loader2` アイコンをフルスクリーン中央に表示
`error.tsx`: エラーメッセージと「再試行」ボタンを表示（`"use client"` 必須）

## 修正された問題
fix #232

<!-- I want to review in Japanese. -->