### PR TITLE
test: Contact・RefreshToken モデルのスペックを追加する

### DIFF
--- a/back/spec/models/contact_spec.rb
+++ b/back/spec/models/contact_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Contact, type: :model do
+  # バリデーション
+  it { should validate_presence_of(:name) }
+  it { should validate_presence_of(:email) }
+  it { should validate_presence_of(:subject) }
+  it { should validate_presence_of(:message) }
+
+  describe 'メールアドレスのバリデーション' do
+    it '正しい形式のメールアドレスは有効' do
+      contact = build(:contact, email: 'valid@example.com')
+      expect(contact).to be_valid
+    end
+
+    it '不正な形式のメールアドレスは無効' do
+      contact = build(:contact, email: 'invalid_email')
+      expect(contact).not_to be_valid
+    end
+  end
+
+  describe 'enum' do
+    it 'デフォルトステータスは pending' do
+      contact = create(:contact)
+      expect(contact.status).to eq('pending')
+    end
+
+    it 'resolved に変更できる' do
+      contact = create(:contact)
+      contact.resolved!
+      expect(contact.status).to eq('resolved')
+    end
+  end
+end

--- a/back/spec/models/refresh_token_spec.rb
+++ b/back/spec/models/refresh_token_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RefreshToken, type: :model do
+  subject { build(:refresh_token) }
+
+  # アソシエーション
+  it { should belong_to(:user) }
+
+  # バリデーション
+  it { should validate_presence_of(:token) }
+  it { should validate_presence_of(:expires_at) }
+  it { should validate_uniqueness_of(:token) }
+
+  describe '.generate_for' do
+    let(:user) { create(:user) }
+
+    it 'ユーザーに紐づくトークンを生成する' do
+      token = described_class.generate_for(user)
+      expect(token).to be_persisted
+      expect(token.user).to eq(user)
+      expect(token.revoked).to be false
+    end
+
+    it '有効期限を14日後に設定する' do
+      token = described_class.generate_for(user)
+      expect(token.expires_at).to be_within(1.minute).of(14.days.from_now)
+    end
+  end
+
+  describe '#active?' do
+    it '有効期限内かつ revoked:false の場合は true を返す' do
+      token = create(:refresh_token)
+      expect(token.active?).to be true
+    end
+
+    it '期限切れの場合は false を返す' do
+      token = create(:refresh_token, :expired)
+      expect(token.active?).to be false
+    end
+
+    it 'revoked の場合は false を返す' do
+      token = create(:refresh_token, :revoked)
+      expect(token.active?).to be false
+    end
+  end
+
+  describe '#revoke!' do
+    it 'revoked を true に更新する' do
+      token = create(:refresh_token)
+      expect { token.revoke! }.to change { token.revoked }.from(false).to(true)
+    end
+  end
+
+  describe '.active scope' do
+    it '有効なトークンのみ返す' do
+      active = create(:refresh_token)
+      create(:refresh_token, :expired)
+      create(:refresh_token, :revoked)
+      expect(described_class.active).to contain_exactly(active)
+    end
+  end
+end

--- a/back/spec/rails_helper.rb
+++ b/back/spec/rails_helper.rb
@@ -34,7 +34,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = Rails.root.join('spec/fixtures').to_s
+  config.fixture_paths = [Rails.root.join('spec/fixtures').to_s]
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要
`Contact` モデルと `RefreshToken` モデルのモデルスペックが存在しなかったため追加する。
また、rspec-rails 8.0 の破壊的変更（`fixture_path=` 削除）も合わせて修正する。

## 詳細な変更点
- [x] `spec/models/contact_spec.rb` を追加
  - バリデーション（name・email・subject・message の presence）
  - メールアドレス形式のバリデーション
  - enum（pending/resolved）の動作確認
- [x] `spec/models/refresh_token_spec.rb` を追加
  - アソシエーション（belongs_to :user）
  - バリデーション（token・expires_at の presence、token の uniqueness）
  - `.generate_for` クラスメソッド
  - `#active?` インスタンスメソッド（有効期限・revoked 判定）
  - `#revoke!` インスタンスメソッド
  - `.active` スコープ
- [x] `spec/rails_helper.rb` の `fixture_path=` → `fixture_paths=` 修正（rspec-rails 8.0 対応）

## 修正された問題
fix #228

<!-- I want to review in Japanese. -->