### PR TITLE
feat: コレクションページのUI/UX改善とuseAchievementsフックを有効化する

### DIFF
--- a/front/src/app/collection/page.tsx
+++ b/front/src/app/collection/page.tsx
@@ -1,45 +1,40 @@
 "use client"
 
 import { useRouter } from "next/navigation"
-import { useState, useEffect} from "react"
-import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from "@/components/ui/card"
+import { useState, useEffect } from "react"
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Progress } from "@/components/ui/progress"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import Image from "next/image"
 import { cn } from "@/lib/utils"
-import { LockIcon, UnlockIcon, AlertTriangle, Trophy } from 'lucide-react';
+import { LockIcon, UnlockIcon, AlertTriangle, Trophy, Gift } from "lucide-react"
 import { useAuth } from "@/hooks/useAuth"
-import { api } from "@/lib/api"
-import type { Achievement, AchievementSummary } from "@/types/achievement"
+import { useAchievements } from "@/hooks/useAchievements"
 
 // カテゴリ表示用の日本語マッピング
 const categoryLabels: Record<string, string> = {
-  all: 'すべて',
-  savings: '貯金',
-  streak: '連続記録',
-  expense: '支出管理',
-  special: '特別'
-};
+  all: "すべて",
+  savings: "貯金",
+  streak: "連続記録",
+  expense: "支出管理",
+  special: "特別",
+}
 
 // ティア表示用の日本語マッピング
 const tierLabels: Record<string, string> = {
-  bronze: 'ブロンズ',
-  silver: 'シルバー',
-  gold: 'ゴールド',
-  platinum: 'プラチナ'
-};
+  bronze: "ブロンズ",
+  silver: "シルバー",
+  gold: "ゴールド",
+  platinum: "プラチナ",
+}
 
 export default function CollectionPage() {
-  const router = useRouter();
-  const { token, isLoading: authIsLoading, isAuthenticated } = useAuth();
-  // 実績関連
-  const [achievements, setAchievements] = useState<Achievement[]>([])
-  const [filteredAchievements, setFilteredAchievements] = useState<Achievement[]>([]);
-  const [activeTab, setActiveTab] = useState("all");
-  const [loadingAchievements, setLoadingAchievements] = useState(true);
-  const [errorAchievements, setErrorAchievements] = useState<string | null>(null);
-  const [achievementSummary, setAchievementSummary] = useState<AchievementSummary | null>(null);
+  const router = useRouter()
+  const { isLoading: authIsLoading, isAuthenticated } = useAuth()
+  const { achievements, summary, isLoading, error } = useAchievements()
+  const [filteredAchievements, setFilteredAchievements] = useState(achievements)
+  const [activeTab, setActiveTab] = useState("all")
 
   // 認証チェック
   useEffect(() => {
@@ -48,95 +43,68 @@ export default function CollectionPage() {
     }
   }, [authIsLoading, isAuthenticated, router])
 
-  /*
-      // 隠し実績
-      ...Array.from({ length: 7 }, (_, i) => ({
-        id: i + 200,
-        title: `未知の実績 ${i + 1}`,
-        description: "この実績の詳細はまだ明かされていません",
-        category: ["savings", "expense", "streak", "special"][Math.floor(Math.random() * 4)] as
-          | "savings"
-          | "expense"
-          | "streak"
-          | "special",
-        isUnlocked: false,
-        progress: 0,
-        imageUrl: "/placeholder.svg?height=120&width=120&text=???",
-      })),
-    ]
-
-    setAchievements(sampleAchievements)
-  }, [])
-*/
-
+  // achievements が更新されたらフィルタを再適用
   useEffect(() => {
-    if (!isAuthenticated || !token) return
-
-    // 実績データを取得
-    const fetchAchievements = async () => {
-      setLoadingAchievements(true);
-      setErrorAchievements(null);
-      try {
-        const data = await api.achievements.list(token);
-        if (data) {
-          setAchievements(data.achievements || []);
-          setFilteredAchievements(data.achievements || []);
-          setAchievementSummary(data.summary || null);
-        }
-      } catch (err) {
-        setErrorAchievements("実績データの取得に失敗しました。時間をおいて再度お試しください。");
-        console.error("Error fetching achievements:", err);
-      } finally {
-        setLoadingAchievements(false);
-      }
-    };
-    fetchAchievements();
-  }, [isAuthenticated, token]);
+    if (activeTab === "all") {
+      setFilteredAchievements(achievements)
+    } else {
+      setFilteredAchievements(achievements.filter((ach) => ach.category === activeTab))
+    }
+  }, [achievements, activeTab])
 
   const filterAchievements = (category: string) => {
-    setActiveTab(category);
-    if (category === "all") {
-      setFilteredAchievements(achievements);
-    } else {
-      setFilteredAchievements(
-        achievements.filter((ach) => ach.category === category)
-      );
-    }
-  };
+    setActiveTab(category)
+  }
 
-  // 表示するカテゴリを動的に生成 (APIから取得したカテゴリを使用することも検討可能)
-  const achievementCategories = ["all", ...new Set(achievements.map(ach => ach.category))];
+  const achievementCategories = ["all", ...new Set(achievements.map((ach) => ach.category))]
+
+  if (authIsLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary" />
+      </div>
+    )
+  }
+
+  if (!isAuthenticated) return null
 
   return (
     <div className="container mx-auto p-4 md:p-6 lg:p-8 bg-background text-foreground">
       <h1 className="text-3xl font-bold mb-8 text-foreground">コレクション</h1>
 
-      {/* 実績サマリー表示 (任意) */}
-      {achievementSummary && !loadingAchievements && !errorAchievements && (
+      {/* 実績サマリー */}
+      {summary && !isLoading && !error && (
         <section className="mb-8 p-4 bg-card text-card-foreground rounded-lg border">
           <h3 className="text-xl font-semibold mb-3 text-card-foreground">実績サマリー</h3>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-center">
             <div>
-              <p className="text-2xl font-bold text-primary">{achievementSummary.total_achievements}</p>
+              <p className="text-2xl font-bold text-primary">{summary.total_achievements}</p>
               <p className="text-sm text-muted-foreground">総実績数</p>
             </div>
             <div>
-              <p className="text-2xl font-bold text-green-600 dark:text-green-400">{achievementSummary.unlocked_achievements}</p>
+              <p className="text-2xl font-bold text-green-600 dark:text-green-400">
+                {summary.unlocked_achievements}
+              </p>
               <p className="text-sm text-muted-foreground">達成済み</p>
             </div>
-            {Object.entries(achievementSummary.progress_by_category).map(([category, summary]) => (
-              summary.total > 0 && ( // カテゴリに実績がある場合のみ表示
-                <div key={category}>
-                  <p className="text-2xl font-bold text-accent-foreground">{summary.progress_percentage}%</p>
-                  <p className="text-sm text-muted-foreground capitalize">{category} 達成率</p>
-                </div>
-              )
-            ))}
+            {Object.entries(summary.progress_by_category).map(
+              ([category, cat]) =>
+                cat.total > 0 && (
+                  <div key={category}>
+                    <p className="text-2xl font-bold text-accent-foreground">
+                      {cat.progress_percentage}%
+                    </p>
+                    <p className="text-sm text-muted-foreground capitalize">
+                      {categoryLabels[category] ?? category} 達成率
+                    </p>
+                  </div>
+                )
+            )}
           </div>
         </section>
       )}
 
-      {/* 実績セクション */}
+      {/* 実績一覧 */}
       <section className="mb-12">
         <div className="flex items-center mb-4">
           <Trophy className="mr-2 h-7 w-7 text-primary" />
@@ -144,55 +112,58 @@ export default function CollectionPage() {
         </div>
         <Tabs value={activeTab} onValueChange={filterAchievements} className="mb-6">
           <TabsList className="bg-muted">
-            {/* カテゴリータブ */}
-            {achievementCategories.map((cat) => (
-              cat && (
-                <TabsTrigger key={cat} value={cat} className="capitalize px-4 py-2 data-[state=active]:bg-background data-[state=active]:text-foreground">
-                  {categoryLabels[cat] || cat}
-                </TabsTrigger>
-              )
-            ))}
+            {achievementCategories.map(
+              (cat) =>
+                cat && (
+                  <TabsTrigger
+                    key={cat}
+                    value={cat}
+                    className="capitalize px-4 py-2 data-[state=active]:bg-background data-[state=active]:text-foreground"
+                  >
+                    {categoryLabels[cat] ?? cat}
+                  </TabsTrigger>
+                )
+            )}
           </TabsList>
         </Tabs>
 
-        {loadingAchievements && (
+        {isLoading && (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
             {[...Array(4)].map((_, i) => (
               <Card key={i} className="flex flex-col animate-pulse bg-card border">
                 <CardHeader className="p-4">
-                  <div className="w-full aspect-[16/9] bg-muted rounded mb-3"></div>
-                  <div className="h-6 w-3/4 bg-muted rounded mb-2"></div>
-                  <div className="h-4 w-full bg-muted rounded"></div>
+                  <div className="w-full aspect-video bg-muted rounded mb-3" />
+                  <div className="h-6 w-3/4 bg-muted rounded mb-2" />
+                  <div className="h-4 w-full bg-muted rounded" />
                 </CardHeader>
-                <CardContent className="flex-grow p-4 pt-0">
-                  <div className="h-4 w-1/2 bg-muted rounded mb-2"></div>
-                  <div className="h-4 w-full bg-muted rounded"></div>
+                <CardContent className="grow p-4 pt-0">
+                  <div className="h-4 w-1/2 bg-muted rounded mb-2" />
+                  <div className="h-4 w-full bg-muted rounded" />
                 </CardContent>
-                <CardFooter className="p-4 pt-0">
-                  <div className="h-8 w-full bg-muted rounded"></div>
-                </CardFooter>
               </Card>
             ))}
           </div>
         )}
 
-        {errorAchievements && (
+        {error && (
           <div className="text-destructive-foreground bg-destructive/10 border border-destructive/20 p-4 rounded-md flex items-center">
-            <AlertTriangle className="h-5 w-5 mr-3 flex-shrink-0" />
+            <AlertTriangle className="h-5 w-5 mr-3 shrink-0" />
             <div>
               <p className="font-semibold">実績データの読み込みエラー</p>
-              <p className="text-sm">{errorAchievements}</p>
+              <p className="text-sm">{error}</p>
             </div>
           </div>
         )}
 
-        {!loadingAchievements && !errorAchievements && filteredAchievements.length === 0 && (
+        {!isLoading && !error && filteredAchievements.length === 0 && (
           <p className="text-muted-foreground py-4">
-            {activeTab === "all" ? "実績はまだありません。" : `このカテゴリ (${activeTab}) の実績はまだありません。`}
+            {activeTab === "all"
+              ? "実績はまだありません。"
+              : `このカテゴリ（${categoryLabels[activeTab] ?? activeTab}）の実績はまだありません。`}
           </p>
         )}
 
-        {!loadingAchievements && !errorAchievements && filteredAchievements.length > 0 && (
+        {!isLoading && !error && filteredAchievements.length > 0 && (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
             {filteredAchievements.map((ach) => (
               <Card
@@ -203,45 +174,60 @@ export default function CollectionPage() {
                 )}
               >
                 <CardHeader className="p-4">
-                  <div className="relative w-full aspect-[16/9] mb-3">
+                  <div className="relative w-full aspect-video mb-3">
                     <Image
                       src={ach.image_url || "/placeholder.svg?text=No+Image"}
                       alt={ach.title}
-                      layout="fill"
-                      objectFit="cover"
-                      className={cn("rounded-md", !ach.unlocked && "opacity-60 grayscale")}
+                      fill
+                      className={cn("rounded-md object-cover", !ach.unlocked && "opacity-60 grayscale")}
                     />
-                    {ach.unlocked && (
+                    {ach.unlocked ? (
                       <Badge className="absolute top-2 right-2 bg-green-500 hover:bg-green-600 text-white text-xs px-2 py-1">
                         <UnlockIcon className="h-3 w-3 mr-1" />達成済
                       </Badge>
-                    )}
-                    {!ach.unlocked && (
-                      <Badge variant="outline" className="absolute top-2 right-2 bg-background border-border text-xs px-2 py-1">
+                    ) : (
+                      <Badge
+                        variant="outline"
+                        className="absolute top-2 right-2 bg-background border-border text-xs px-2 py-1"
+                      >
                         <LockIcon className="h-3 w-3 mr-1" />未達成
                       </Badge>
                     )}
                   </div>
-                  <CardTitle className="text-md font-semibold leading-tight text-card-foreground">{ach.title}</CardTitle>
-                  <CardDescription className="text-xs h-10 overflow-hidden text-ellipsis text-muted-foreground">{ach.description}</CardDescription>
+                  <CardTitle className="text-md font-semibold leading-tight text-card-foreground">
+                    {ach.title}
+                  </CardTitle>
+                  <CardDescription className="text-xs h-10 overflow-hidden text-ellipsis text-muted-foreground">
+                    {ach.description}
+                  </CardDescription>
                 </CardHeader>
-                <CardContent className="flex-grow p-4 pt-0">
-                  {ach.tier && <Badge variant="secondary" className="mb-2 text-xs bg-secondary text-secondary-foreground">Tier {ach.tier}</Badge>}
-                  <Progress value={ach.progress_percentage} className="w-full h-2 my-1" />
-                  <p className="text-xs text-muted-foreground mt-1">
-                    {ach.progress_percentage}% 完了 ({ach.progress} / {ach.progress_target})
+
+                <CardContent className="grow p-4 pt-0 space-y-2">
+                  {ach.tier && (
+                    <Badge
+                      variant="secondary"
+                      className="text-xs bg-secondary text-secondary-foreground"
+                    >
+                      {tierLabels[ach.tier] ?? ach.tier}
+                    </Badge>
+                  )}
+                  <Progress value={ach.progress_percentage} className="w-full h-2" />
+                  <p className="text-sm font-medium text-foreground">
+                    {ach.progress} / {ach.progress_target}
                   </p>
+                  <p className="text-xs text-muted-foreground">{ach.progress_percentage}% 完了</p>
+                  {ach.reward && (
+                    <div className="flex items-center gap-1.5 mt-2 rounded-md bg-primary/10 px-3 py-2">
+                      <Gift className="h-4 w-4 text-primary shrink-0" />
+                      <p className="text-xs font-semibold text-primary">{ach.reward}</p>
+                    </div>
+                  )}
                 </CardContent>
-                {ach.reward && (
-                  <CardFooter className="p-4 pt-0">
-                    <p className="text-xs text-primary font-medium">報酬: {ach.reward}</p>
-                  </CardFooter>
-                )}
               </Card>
             ))}
           </div>
         )}
       </section>
     </div>
-  );
+  )
 }

--- a/front/src/hooks/useAchievements.ts
+++ b/front/src/hooks/useAchievements.ts
@@ -1,122 +1,43 @@
-// import { useState, useCallback } from 'react';
-// import { toast } from 'sonner';
-// import { type Achievement as FrontendAchievement } from '@/app/collection/page'; // collection/page.tsx から型をインポート
-
-// バックエンドAPIのレスポンス型 (collection/page.tsx と同じものを再定義または共有)
-// もし型定義を共通化したい場合は、types/index.ts のようなファイルに移動することを検討してください。
-/*
-type ApiAchievementResponse = {
-  id: number; // DB上の achievement.id
-  original_achievement_id: number;
-  title: string;
-  description: string;
-  category: string;
-  unlocked: boolean;
-  progress: number;
-  image_url: string | null;
-  reward: string | null;
-  tier: number | null;
-  // created_at, updated_at など、APIが返す他のフィールドも必要に応じて追加
-};
-
-// APIレスポンスをフロントエンドの型に変換するヘルパー関数
-const mapApiToFrontend = (apiAch: ApiAchievementResponse): FrontendAchievement => {
-  return {
-    id: apiAch.original_achievement_id,
-    dbId: apiAch.id,
-    title: apiAch.title,
-    description: apiAch.description,
-    category: apiAch.category,
-    isUnlocked: apiAch.unlocked,
-    progress: apiAch.progress,
-    imageUrl: apiAch.image_url || `/placeholder.svg?height=120&width=120&text=${encodeURIComponent(apiAch.title.substring(0,10))}`,
-    reward: apiAch.reward || undefined,
-    tier: apiAch.tier || undefined,
-  };
-};
+import { useState, useEffect } from "react"
+import { useAuth } from "@/hooks/useAuth"
+import { api } from "@/lib/api"
+import type { Achievement, AchievementSummary } from "@/types/achievement"
 
 type UseAchievementsReturn = {
-  updateAchievement: (
-    achievementOriginalId: number,
-    newProgress: number,
-    isNowUnlocked: boolean
-  ) => Promise<FrontendAchievement | null>;
-  isLoading: boolean;
-  error: string | null;
-};
+  achievements: Achievement[]
+  summary: AchievementSummary | null
+  isLoading: boolean
+  error: string | null
+}
 
 export const useAchievements = (): UseAchievementsReturn => {
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const { token, isAuthenticated } = useAuth()
+  const [achievements, setAchievements] = useState<Achievement[]>([])
+  const [summary, setSummary] = useState<AchievementSummary | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
 
-  const updateAchievement = useCallback(
-    async (
-      achievementOriginalId: number,
-      newProgress: number,
-      isNowUnlocked: boolean
-    ): Promise<FrontendAchievement | null> => {
-      const token = localStorage.getItem('authToken');
-      if (!token) {
-        const msg = '認証情報がありません。実績を更新できませんでした。';
-        console.error(msg);
-        toast.error(msg);
-        setError(msg);
-        return null;
-      }
+  useEffect(() => {
+    if (!isAuthenticated || !token) return
 
-      setIsLoading(true);
-      setError(null);
-
+    const fetchAchievements = async () => {
+      setIsLoading(true)
+      setError(null)
       try {
-        const response = await fetch(
-          `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/achievements/${achievementOriginalId}`,
-          {
-            method: 'PUT', // または 'PATCH'
-            headers: {
-              'Content-Type': 'application/json',
-              Authorization: `Bearer ${token}`,
-            },
-            body: JSON.stringify({
-              progress: newProgress,
-              unlocked: isNowUnlocked,
-            }),
-          }
-        );
-
-        if (!response.ok) {
-          let errorMsg = `実績の更新に失敗しました (Status: ${response.status})`;
-          try {
-            const errorData = await response.json();
-            errorMsg = `実績の更新に失敗しました: ${errorData.errors?.join(', ') || errorData.error || response.statusText}`;
-          } catch (e) {
-            // JSONパースに失敗した場合
-            console.warn("Failed to parse error response as JSON");
-          }
-          console.error(errorMsg, { status: response.status, statusText: response.statusText });
-          toast.error(errorMsg);
-          setError(errorMsg);
-          return null;
+        const data = await api.achievements.list(token)
+        if (data) {
+          setAchievements(data.achievements || [])
+          setSummary(data.summary || null)
         }
-
-        const updatedApiAchievement: ApiAchievementResponse = await response.json();
-        toast.success(`実績「${updatedApiAchievement.title}」を更新しました！`);
-        
-        const frontendAchievement = mapApiToFrontend(updatedApiAchievement);
-        return frontendAchievement;
-
       } catch (err) {
-        const catchMsg = '実績の更新中に予期せぬエラーが発生しました。';
-        console.error(catchMsg, err);
-        toast.error(catchMsg);
-        setError(catchMsg);
-        return null;
+        setError("実績データの取得に失敗しました。時間をおいて再度お試しください。")
+        console.error("Error fetching achievements:", err)
       } finally {
-        setIsLoading(false);
+        setIsLoading(false)
       }
-    },
-    [] // 依存配列は空でOK (localStorage, process.env は外部依存)
-  );
+    }
+    fetchAchievements()
+  }, [isAuthenticated, token])
 
-  return { updateAchievement, isLoading, error };
-};
-*/
+  return { achievements, summary, isLoading, error }
+}


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要
コレクションページの表示品質を向上させ、セキュリティ規約への準拠も合わせて対応する。

## 詳細な変更点
- [x] 進捗表示を `{progress}/{progress_target}` 形式で主体的に表示（`%` は補助表示に変更）
- [x] リワードテキストをアイコン（🎁）付きハイライトカードで目立つ形に変更
- [x] `useAchievements` フックを再実装（コメントアウト解除）
  - `localStorage` 直接アクセスを `useAuth` フック経由に修正（セキュリティ規約準拠）
  - `fetchAchievements` ロジックをフックに集約
- [x] `collection/page.tsx` のデータ取得を `useAchievements` フックに委譲
- [x] ティア表示を日本語ラベル（ブロンズ / シルバー / ゴールド / プラチナ）に統一
- [x] Tailwind canonical class の警告を修正（`aspect-[16/9]` → `aspect-video`、`flex-grow` → `grow` 等）

## 修正された問題
fix #205

<!-- I want to review in Japanese. -->