### PR TITLE
feat: 実績の掲示板シェア機能を実装する

### DIFF
--- a/front/src/app/board/page.tsx
+++ b/front/src/app/board/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useEffect, useCallback } from "react"
-import { useRouter } from "next/navigation"
+import { useRouter, useSearchParams } from "next/navigation"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -44,6 +44,7 @@ const SORT_OPTIONS = [
 export default function BoardPage() {
   const router = useRouter()
   const { user, token, isLoading: authIsLoading, isAuthenticated } = useAuth()
+  const searchParams = useSearchParams()
 
   const [posts, setPosts] = useState<Post[]>([])
   const [likedPostIds, setLikedPostIds] = useState<string[]>([])
@@ -86,6 +87,27 @@ export default function BoardPage() {
       router.push("/login")
     }
   }, [authIsLoading, isAuthenticated, router])
+
+  // 実績シェアのクエリパラメータ処理
+  useEffect(() => {
+    const shareTitle = searchParams.get("shareTitle")
+    const shareTier = searchParams.get("shareTier")
+    if (!shareTitle) return
+
+    const tierLabel: Record<string, string> = {
+      bronze: "ブロンズ",
+      silver: "シルバー",
+      gold: "ゴールド",
+      platinum: "プラチナ",
+    }
+    const tier = shareTier ? (tierLabel[shareTier] ?? shareTier) : null
+    const tierTag = tier ? ` #${tier}` : ""
+
+    setNewPostTitle(`「${shareTitle}」を達成しました！`)
+    setNewPostContent(`「${shareTitle}」を達成しました！🦦${tierTag}\n\n`)
+    setNewPostCategories(["experience"])
+    setIsNewPostDialogOpen(true)
+  }, [searchParams])
 
   // 投稿一覧を取得
   const fetchPosts = useCallback(async () => {

--- a/front/src/app/collection/page.tsx
+++ b/front/src/app/collection/page.tsx
@@ -8,7 +8,7 @@ import { Progress } from "@/components/ui/progress"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import Image from "next/image"
 import { cn } from "@/lib/utils"
-import { LockIcon, UnlockIcon, AlertTriangle, Trophy } from 'lucide-react';
+import { LockIcon, UnlockIcon, AlertTriangle, Trophy, Share2 } from 'lucide-react';
 import { useAuth } from "@/hooks/useAuth"
 import { api } from "@/lib/api"
 import type { Achievement, AchievementSummary } from "@/types/achievement"
@@ -232,11 +232,26 @@ export default function CollectionPage() {
                     {ach.progress_percentage}% 完了 ({ach.progress} / {ach.progress_target})
                   </p>
                 </CardContent>
-                {ach.reward && (
-                  <CardFooter className="p-4 pt-0">
+                <CardFooter className="p-4 pt-0 flex flex-col gap-2 items-start">
+                  {ach.reward && (
                     <p className="text-xs text-primary font-medium">報酬: {ach.reward}</p>
-                  </CardFooter>
-                )}
+                  )}
+                  {ach.unlocked && (
+                    <button
+                      onClick={() => {
+                        const params = new URLSearchParams({
+                          shareTitle: ach.title,
+                          shareTier: ach.tier ?? "",
+                        })
+                        router.push(`/board?${params.toString()}`)
+                      }}
+                      className="flex items-center gap-1 text-xs text-muted-foreground hover:text-primary transition-colors"
+                    >
+                      <Share2 className="h-3 w-3" />
+                      掲示板でシェア
+                    </button>
+                  )}
+                </CardFooter>
               </Card>
             ))}
           </div>


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要
解除した実績を掲示板でシェアできるようにし、コミュニティ機能との連携を強化する。

## 詳細な変更点
- [x] コレクションページの解除済み実績カードに「掲示板でシェア」ボタンを追加
- [x] ボタン押下で `/board?shareTitle=<title>&shareTier=<tier>` へ遷移
- [x] 掲示板（`/board`）で `useSearchParams` によりクエリパラメータを受け取り
  - 投稿タイトルを `「{title}」を達成しました！` に自動入力
  - 投稿内容を `「{title}」を達成しました！🦦 #{tier}` に自動入力
  - カテゴリーを「体験談」に自動設定
  - 投稿ダイアログを自動で開く

## 修正された問題
fix #202

<!-- I want to review in Japanese. -->