### PR TITLE
feat: 掲示板投稿にページネーションを実装する

### DIFF
--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -11,8 +11,17 @@ module Api
         action_name.in?(%w[index show increment_views])
       end
 
+      PER_PAGE = 20
+
       def index
-        @posts = Post.includes(:user, :categories).order(created_at: :desc)
+        page = params[:page].to_i.clamp(1, Float::INFINITY).to_i
+        per  = params[:per].to_i.zero? ? PER_PAGE : params[:per].to_i.clamp(1, 100)
+
+        scope       = Post.includes(:user, :categories).order(created_at: :desc)
+        total_count = scope.count
+        @posts      = scope.limit(per).offset((page - 1) * per)
+        total_pages = (total_count.to_f / per).ceil
+
         viewer = optional_current_user
         post_ids = @posts.map(&:id)
         liked_ids = if viewer
@@ -22,7 +31,16 @@ module Api
                       [].to_set
                     end
         bookmarked_ids = viewer ? Bookmark.where(post_id: post_ids, user: viewer).pluck(:post_id).to_set : [].to_set
-        render json: @posts.map { |post| post_json(post, liked_ids: liked_ids, bookmarked_ids: bookmarked_ids) }
+
+        render json: {
+          posts: @posts.map { |post| post_json(post, liked_ids: liked_ids, bookmarked_ids: bookmarked_ids) },
+          meta: {
+            current_page: page,
+            total_pages: total_pages,
+            total_count: total_count,
+            per_page: per
+          }
+        }
       end
 
       def show
@@ -39,7 +57,7 @@ module Api
         if @post.save
           render json: post_json(@post), status: :created
         else
-          render json: { errors: @post.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: @post.errors.full_messages }, status: :unprocessable_content
         end
       end
 
@@ -53,7 +71,7 @@ module Api
           assign_categories(@post)
           render json: post_json(@post)
         else
-          render json: { errors: @post.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: @post.errors.full_messages }, status: :unprocessable_content
         end
       end
 
@@ -75,13 +93,13 @@ module Api
       private
 
       def set_post_with_associations
-        @post = Post.includes(:user, :categories).find(params[:id])
+        @post = Post.includes(:user, :categories).find(params.expect(:id))
       rescue ActiveRecord::RecordNotFound
         render json: { error: '投稿が見つかりません' }, status: :not_found
       end
 
       def set_post
-        @post = Post.find(params[:id])
+        @post = Post.find(params.expect(:id))
       rescue ActiveRecord::RecordNotFound
         render json: { error: '投稿が見つかりません' }, status: :not_found
       end

--- a/front/src/app/board/page.tsx
+++ b/front/src/app/board/page.tsx
@@ -52,6 +52,9 @@ export default function BoardPage() {
   const [filteredPosts, setFilteredPosts] = useState<Post[]>([])
   const [bookmarkedPosts, setBookmarkedPosts] = useState<string[]>([])
   const [isPostsLoading, setIsPostsLoading] = useState(false)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [currentPage, setCurrentPage] = useState(1)
+  const [totalPages, setTotalPages] = useState(1)
 
   // ダイアログの状態
   const [isNewPostDialogOpen, setIsNewPostDialogOpen] = useState(false)
@@ -87,16 +90,18 @@ export default function BoardPage() {
     }
   }, [authIsLoading, isAuthenticated, router])
 
-  // 投稿一覧を取得
+  // 投稿一覧を取得（page=1 でリセット）
   const fetchPosts = useCallback(async () => {
     if (!token) return
     setIsPostsLoading(true)
     try {
-      const data = await api.posts.list(token)
+      const data = await api.posts.list(token, 1)
       if (data) {
-        setPosts(data.map(mapApiPost))
-        setLikedPostIds(data.filter((p) => p.liked_by_me).map((p) => String(p.id)))
-        setBookmarkedPosts(data.filter((p) => p.bookmarked_by_me).map((p) => String(p.id)))
+        setPosts(data.posts.map(mapApiPost))
+        setLikedPostIds(data.posts.filter((p) => p.liked_by_me).map((p) => String(p.id)))
+        setBookmarkedPosts(data.posts.filter((p) => p.bookmarked_by_me).map((p) => String(p.id)))
+        setCurrentPage(1)
+        setTotalPages(data.meta.total_pages)
       }
     } catch (err) {
       console.error("投稿取得エラー:", err)
@@ -105,6 +110,34 @@ export default function BoardPage() {
       setIsPostsLoading(false)
     }
   }, [token])
+
+  // 追加読み込み
+  const handleLoadMore = async () => {
+    if (!token || isLoadingMore || currentPage >= totalPages) return
+    setIsLoadingMore(true)
+    const nextPage = currentPage + 1
+    try {
+      const data = await api.posts.list(token, nextPage)
+      if (data) {
+        setPosts((prev) => [...prev, ...data.posts.map(mapApiPost)])
+        setLikedPostIds((prev) => [
+          ...prev,
+          ...data.posts.filter((p) => p.liked_by_me).map((p) => String(p.id)),
+        ])
+        setBookmarkedPosts((prev) => [
+          ...prev,
+          ...data.posts.filter((p) => p.bookmarked_by_me).map((p) => String(p.id)),
+        ])
+        setCurrentPage(nextPage)
+        setTotalPages(data.meta.total_pages)
+      }
+    } catch (err) {
+      console.error("追加読み込みエラー:", err)
+      toast.error("投稿の読み込みに失敗しました")
+    } finally {
+      setIsLoadingMore(false)
+    }
+  }
 
   useEffect(() => {
     if (isAuthenticated && token) {
@@ -637,6 +670,24 @@ export default function BoardPage() {
             {renderPostList(filteredPosts)}
           </TabsContent>
         ))}
+
+        {/* もっと読み込む */}
+        {currentPage < totalPages && (
+          <div className="flex justify-center mt-6">
+            <Button
+              variant="outline"
+              onClick={handleLoadMore}
+              disabled={isLoadingMore}
+              className="min-w-32"
+            >
+              {isLoadingMore ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                `もっと見る（${currentPage}/${totalPages}ページ）`
+              )}
+            </Button>
+          </div>
+        )}
       </Tabs>
 
       {/* 新規投稿ダイアログ */}

--- a/front/src/lib/api.ts
+++ b/front/src/lib/api.ts
@@ -1,6 +1,6 @@
 import { apiRequest, publicApiRequest } from '@/lib/api-client'
 import type { ApiTransaction } from '@/types/transaction'
-import type { ApiPost, ApiComment } from '@/types/post'
+import type { ApiPost, ApiComment, ApiPostsResponse } from '@/types/post'
 import type { AchievementResponse } from '@/types/achievement'
 
 // ========== 型定義 ==========
@@ -110,9 +110,9 @@ export const api = {
 
   /** 投稿 */
   posts: {
-    /** 投稿一覧を取得する */
-    list: (token: string) =>
-      apiRequest<ApiPost[]>('/posts', { token }),
+    /** 投稿一覧を取得する（page: ページ番号, per: 1ページあたりの件数） */
+    list: (token: string, page = 1, per = 20) =>
+      apiRequest<ApiPostsResponse>(`/posts?page=${page}&per=${per}`, { token }),
 
     /** 投稿を作成する */
     create: (token: string, params: CreatePostParams) =>

--- a/front/src/types/post.ts
+++ b/front/src/types/post.ts
@@ -1,3 +1,14 @@
+/** 投稿一覧 API レスポンス型（ページネーション付き） */
+export type ApiPostsResponse = {
+  posts: ApiPost[]
+  meta: {
+    current_page: number
+    total_pages: number
+    total_count: number
+    per_page: number
+  }
+}
+
 /** Rails API レスポンス型 — 投稿 */
 export type ApiPost = {
   id: number


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要
`PostsController#index` が全件取得しており、投稿数が増えるとレスポンスが遅くなるため、ページネーションを実装する。

## 詳細な変更点
### バックエンド
- [x] `PostsController#index` に `page`・`per` クエリパラメータを追加
  - `page` デフォルト: 1、`per` デフォルト: 20（最大100）
  - レスポンスを `{ posts: [...], meta: { current_page, total_pages, total_count, per_page } }` 形式に変更

### フロントエンド
- [x] `types/post.ts` に `ApiPostsResponse` 型を追加
- [x] `api.ts` の `posts.list` を `page`・`per` パラメータ対応に更新
- [x] 掲示板ページに「もっと見る」ボタンを追加（追加読み込み方式）
  - 読み込み中は `Loader2` スピナーを表示
  - 全件読み込み済みの場合はボタンを非表示

## 修正された問題
fix #226

<!-- I want to review in Japanese. -->