### PR TITLE
security: リフレッシュトークンをDB平文保存からハッシュ保存に変更する (#193)

### DIFF
--- a/back/app/controllers/api/v1/auth_controller.rb
+++ b/back/app/controllers/api/v1/auth_controller.rb
@@ -84,9 +84,9 @@ module Api
         new_refresh_token = nil
 
         ActiveRecord::Base.transaction do
-          refresh_token = RefreshToken.lock.find_by(token: token_value)
+          refresh_token = RefreshToken.lock.find_active_by_token(token_value)
 
-          unless refresh_token&.active?
+          unless refresh_token
             render json: { error: 'リフレッシュトークンが無効または期限切れです', code: 'invalid_refresh_token' },
                    status: :unauthorized
             raise ActiveRecord::Rollback

--- a/back/app/controllers/api/v1/sessions_controller.rb
+++ b/back/app/controllers/api/v1/sessions_controller.rb
@@ -50,7 +50,7 @@ module Api
       def destroy
         token_value = params[:refresh_token]
         if token_value
-          refresh_token = RefreshToken.find_by(token: token_value)
+          refresh_token = RefreshToken.find_by_plain_token(token_value)
           refresh_token&.revoke!
         end
 

--- a/back/app/models/refresh_token.rb
+++ b/back/app/models/refresh_token.rb
@@ -3,17 +3,42 @@
 class RefreshToken < ApplicationRecord
   belongs_to :user
 
-  validates :token, presence: true, uniqueness: true
+  attr_accessor :token # 平文トークンを保持する
+
+  validates :token_digest, presence: true, uniqueness: true
   validates :expires_at, presence: true
+
+  before_validation :set_token_digest, if: -> { token.present? }
 
   scope :active, -> { where(revoked: false).where('expires_at > ?', Time.current) }
 
   def self.generate_for(user)
-    create!(
+    plain_token = SecureRandom.hex(32)
+    refresh_token = new(
       user: user,
-      token: SecureRandom.hex(32),
+      token: plain_token,
       expires_at: 14.days.from_now
     )
+    refresh_token.save!
+    refresh_token
+  end
+
+  def self.find_active_by_token(plain_token)
+    record = find_by_plain_token(plain_token)
+    record&.active? ? record : nil
+  end
+
+  def self.find_by_plain_token(plain_token)
+    # DB検索による一致確認後、secure_compareでの固定時間比較を行い、タイミング攻撃を防ぐ
+    record = find_by(token_digest: digest(plain_token))
+    return nil unless record
+    return record if ActiveSupport::SecurityUtils.secure_compare(record.token_digest, digest(plain_token))
+    
+    nil
+  end
+
+  def self.digest(plain_token)
+    OpenSSL::HMAC.hexdigest('SHA256', Rails.application.credentials.secret_key_base || ENV.fetch('JWT_SECRET', 'fallback'), plain_token.to_s)
   end
 
   def active?
@@ -22,5 +47,11 @@ class RefreshToken < ApplicationRecord
 
   def revoke!
     update!(revoked: true)
+  end
+
+  private
+
+  def set_token_digest
+    self.token_digest = self.class.digest(token)
   end
 end

--- a/back/db/migrate/20260601234704_change_token_to_token_digest_in_refresh_tokens.rb
+++ b/back/db/migrate/20260601234704_change_token_to_token_digest_in_refresh_tokens.rb
@@ -1,0 +1,7 @@
+class ChangeTokenToTokenDigestInRefreshTokens < ActiveRecord::Migration[7.1]
+  def change
+    # 既存のリフレッシュトークンは平文で保存されており、ダイジェスト化されたものと照合できなくなるため、
+    # 自動的に無効化されます（セキュリティ上安全）
+    rename_column :refresh_tokens, :token, :token_digest
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_31_000002) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_01_234704) do
   create_table "achievements", force: :cascade do |t|
     t.integer "category", default: 0, null: false
     t.datetime "created_at", null: false
@@ -123,10 +123,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_31_000002) do
     t.datetime "created_at", null: false
     t.datetime "expires_at", null: false
     t.boolean "revoked", default: false, null: false
-    t.string "token", null: false
+    t.string "token_digest", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
-    t.index ["token"], name: "index_refresh_tokens_on_token", unique: true
+    t.index ["token_digest"], name: "index_refresh_tokens_on_token_digest", unique: true
     t.index ["user_id"], name: "index_refresh_tokens_on_user_id"
   end
 

--- a/back/spec/models/refresh_token_spec.rb
+++ b/back/spec/models/refresh_token_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe RefreshToken, type: :model do
   it { should belong_to(:user) }
 
   # バリデーション
-  it { should validate_presence_of(:token) }
+  it { should validate_presence_of(:token_digest) }
   it { should validate_presence_of(:expires_at) }
-  it { should validate_uniqueness_of(:token) }
+  it { should validate_uniqueness_of(:token_digest) }
 
   describe '.generate_for' do
     let(:user) { create(:user) }


### PR DESCRIPTION
Fixes #193