### PR TITLE
security: リフレッシュトークンを HttpOnly Cookie に移行する (#194 #195)

### DIFF
--- a/back/app/controllers/api/v1/auth_controller.rb
+++ b/back/app/controllers/api/v1/auth_controller.rb
@@ -82,7 +82,7 @@ module Api
         new_refresh_token = nil
 
         ActiveRecord::Base.transaction do
-          refresh_token = RefreshToken.lock.find_active_by_token(token_value)
+          refresh_token = RefreshToken.find_active_by_token(token_value)
 
           unless refresh_token
             render json: { error: 'リフレッシュトークンが無効または期限切れです', code: 'invalid_refresh_token' },

--- a/back/app/controllers/api/v1/auth_controller.rb
+++ b/back/app/controllers/api/v1/auth_controller.rb
@@ -84,9 +84,9 @@ module Api
         new_refresh_token = nil
 
         ActiveRecord::Base.transaction do
-          refresh_token = RefreshToken.lock.find_by(token: token_value)
+          refresh_token = RefreshToken.lock.find_active_by_token(token_value)
 
-          unless refresh_token&.active?
+          unless refresh_token
             render json: { error: 'リフレッシュトークンが無効または期限切れです', code: 'invalid_refresh_token' },
                    status: :unauthorized
             raise ActiveRecord::Rollback

--- a/back/app/controllers/api/v1/auth_controller.rb
+++ b/back/app/controllers/api/v1/auth_controller.rb
@@ -3,8 +3,6 @@
 module Api
   module V1
     class AuthController < ApplicationController
-      include ActionController::Cookies
-
       skip_before_action :authorize_request, only: %i[google google_callback auth_failure verify refresh]
 
       # Googleログインへのリダイレクト
@@ -21,11 +19,11 @@ module Api
           token = JsonWebToken.encode(user_id: user.id)
           refresh_token = RefreshToken.generate_for(user)
           # フロントエンドへリダイレクト（トークンを含む）
-          callback_url = "#{ENV.fetch('FRONTEND_URL', nil)}/auth/callback" \
-                         "?token=#{token}&refresh_token=#{refresh_token.token}"
+          write_refresh_token_cookie(refresh_token.token)
+          callback_url = "#{ENV.fetch('FRONTEND_URL', nil)}/auth/callback?token=#{token}"
           redirect_to callback_url
         else
-          render json: { error: 'OAuth認証に失敗しました' }, status: :unprocessable_entity
+          render json: { error: 'OAuth認証に失敗しました' }, status: :unprocessable_content
         end
       end
 
@@ -73,7 +71,7 @@ module Api
 
       # リフレッシュトークンを使ってアクセストークンを再発行する
       def refresh
-        token_value = params[:refresh_token]
+        token_value = cookies[:refresh_token]
 
         unless token_value
           render json: { error: 'リフレッシュトークンが必要です', code: 'missing_refresh_token' }, status: :bad_request
@@ -100,9 +98,10 @@ module Api
 
         return unless new_token
 
+        write_refresh_token_cookie(new_refresh_token.token)
+
         render json: {
-          token: new_token,
-          refresh_token: new_refresh_token.token
+          token: new_token
         }, status: :ok
       end
     end

--- a/back/app/controllers/api/v1/guest_sessions_controller.rb
+++ b/back/app/controllers/api/v1/guest_sessions_controller.rb
@@ -13,12 +13,12 @@ module Api
 
         token = JsonWebToken.encode(user_id: user.id)
         refresh_token = RefreshToken.generate_for(user)
+        write_refresh_token_cookie(refresh_token.token)
 
         render json: {
           logged_in: true,
           user: user.as_json(except: [:password_digest]),
-          token: token,
-          refresh_token: refresh_token.token
+          token: token
         }
       end
     end

--- a/back/app/controllers/api/v1/sessions_controller.rb
+++ b/back/app/controllers/api/v1/sessions_controller.rb
@@ -30,11 +30,11 @@ module Api
           Rails.logger.info "Authentication successful for user: #{user.id}" if Rails.env.development?
           token = JsonWebToken.encode(user_id: user.id)
           refresh_token = RefreshToken.generate_for(user)
+          write_refresh_token_cookie(refresh_token.token)
           render json: {
             status: 'success',
             message: 'ログインに成功しました。',
             token: token,
-            refresh_token: refresh_token.token,
             user: user.as_json(only: %i[id email username]) # 必要に応じてユーザー情報を返す
           }, status: :ok
         else
@@ -48,11 +48,13 @@ module Api
 
       # DELETE /api/v1/sessions
       def destroy
-        token_value = params[:refresh_token]
+        token_value = cookies[:refresh_token]
         if token_value
-          refresh_token = RefreshToken.find_by_plain_token(token_value)
+          refresh_token = RefreshToken.find_active_by_token(token_value)
           refresh_token&.revoke!
         end
+
+        cookies.delete(:refresh_token)
 
         render json: {
           status: 'success',

--- a/back/app/controllers/api/v1/sessions_controller.rb
+++ b/back/app/controllers/api/v1/sessions_controller.rb
@@ -50,7 +50,7 @@ module Api
       def destroy
         token_value = params[:refresh_token]
         if token_value
-          refresh_token = RefreshToken.find_by(token: token_value)
+          refresh_token = RefreshToken.find_by_plain_token(token_value)
           refresh_token&.revoke!
         end
 

--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -19,15 +19,15 @@ module Api
         if user.save
           token = JsonWebToken.encode(user_id: user.id)
           refresh_token = RefreshToken.generate_for(user)
+          write_refresh_token_cookie(refresh_token.token)
           render json: {
             status: 'success',
             message: 'ユーザー登録が正常に完了しました。',
             user: user.as_json(only: %i[id email username]),
-            token: token,
-            refresh_token: refresh_token.token
+            token: token
           }, status: :created
         else
-          render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: user.errors.full_messages }, status: :unprocessable_content
         end
       end
 
@@ -40,7 +40,7 @@ module Api
             name: @current_user.name
           }
         else
-          render json: { errors: @current_user.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: @current_user.errors.full_messages }, status: :unprocessable_content
         end
       end
 

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@
 
 class ApplicationController < ActionController::API
   include ExceptionHandler
+  include ActionController::Cookies
 
   before_action :authorize_request
 
@@ -38,6 +39,16 @@ class ApplicationController < ActionController::API
   end
 
   private
+
+  def write_refresh_token_cookie(token)
+    cookies[:refresh_token] = {
+      value: token,
+      httponly: true,
+      secure: Rails.env.production?,
+      same_site: Rails.env.production? ? :none : :lax,
+      expires: 14.days.from_now
+    }
+  end
 
   def authorize_request
     # 特定のエンドポイントではスキップ

--- a/back/app/models/refresh_token.rb
+++ b/back/app/models/refresh_token.rb
@@ -3,17 +3,42 @@
 class RefreshToken < ApplicationRecord
   belongs_to :user
 
-  validates :token, presence: true, uniqueness: true
+  attr_accessor :token # 平文トークンを保持する
+
+  validates :token_digest, presence: true, uniqueness: true
   validates :expires_at, presence: true
+
+  before_validation :set_token_digest, if: -> { token.present? }
 
   scope :active, -> { where(revoked: false).where('expires_at > ?', Time.current) }
 
   def self.generate_for(user)
-    create!(
+    plain_token = SecureRandom.hex(32)
+    refresh_token = new(
       user: user,
-      token: SecureRandom.hex(32),
+      token: plain_token,
       expires_at: 14.days.from_now
     )
+    refresh_token.save!
+    refresh_token
+  end
+
+  def self.find_active_by_token(plain_token)
+    record = find_by_plain_token(plain_token)
+    record&.active? ? record : nil
+  end
+
+  def self.find_by_plain_token(plain_token)
+    # DB検索による一致確認後、secure_compareでの固定時間比較を行い、タイミング攻撃を防ぐ
+    record = find_by(token_digest: digest(plain_token))
+    return nil unless record
+    return record if ActiveSupport::SecurityUtils.secure_compare(record.token_digest, digest(plain_token))
+    
+    nil
+  end
+
+  def self.digest(plain_token)
+    OpenSSL::HMAC.hexdigest('SHA256', Rails.application.credentials.secret_key_base || ENV.fetch('JWT_SECRET', 'fallback'), plain_token.to_s)
   end
 
   def active?
@@ -22,5 +47,11 @@ class RefreshToken < ApplicationRecord
 
   def revoke!
     update!(revoked: true)
+  end
+
+  private
+
+  def set_token_digest
+    self.token_digest = self.class.digest(token)
   end
 end

--- a/back/app/models/refresh_token.rb
+++ b/back/app/models/refresh_token.rb
@@ -24,7 +24,8 @@ class RefreshToken < ApplicationRecord
   end
 
   def self.find_active_by_token(plain_token)
-    record = find_by_plain_token(plain_token)
+    # SELECT ... FOR UPDATE でロックして並行リプレイ攻撃を防ぐ
+    record = lock.find_by(token_digest: digest(plain_token))
     record&.active? ? record : nil
   end
 
@@ -33,12 +34,13 @@ class RefreshToken < ApplicationRecord
     record = find_by(token_digest: digest(plain_token))
     return nil unless record
     return record if ActiveSupport::SecurityUtils.secure_compare(record.token_digest, digest(plain_token))
-    
+
     nil
   end
 
   def self.digest(plain_token)
-    OpenSSL::HMAC.hexdigest('SHA256', Rails.application.credentials.secret_key_base || ENV.fetch('JWT_SECRET', 'fallback'), plain_token.to_s)
+    secret = Rails.application.credentials.secret_key_base || ENV.fetch('JWT_SECRET', 'fallback')
+    OpenSSL::HMAC.hexdigest('SHA256', secret, plain_token.to_s)
   end
 
   def active?

--- a/back/db/migrate/20260601234704_change_token_to_token_digest_in_refresh_tokens.rb
+++ b/back/db/migrate/20260601234704_change_token_to_token_digest_in_refresh_tokens.rb
@@ -1,0 +1,7 @@
+class ChangeTokenToTokenDigestInRefreshTokens < ActiveRecord::Migration[7.1]
+  def change
+    # 既存のリフレッシュトークンは平文で保存されており、ダイジェスト化されたものと照合できなくなるため、
+    # 自動的に無効化されます（セキュリティ上安全）
+    rename_column :refresh_tokens, :token, :token_digest
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_31_000002) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_01_234704) do
   create_table "achievements", force: :cascade do |t|
     t.integer "category", default: 0, null: false
     t.datetime "created_at", null: false
@@ -123,10 +123,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_31_000002) do
     t.datetime "created_at", null: false
     t.datetime "expires_at", null: false
     t.boolean "revoked", default: false, null: false
-    t.string "token", null: false
+    t.string "token_digest", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
-    t.index ["token"], name: "index_refresh_tokens_on_token", unique: true
+    t.index ["token_digest"], name: "index_refresh_tokens_on_token_digest", unique: true
     t.index ["user_id"], name: "index_refresh_tokens_on_user_id"
   end
 

--- a/back/spec/models/refresh_token_spec.rb
+++ b/back/spec/models/refresh_token_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe RefreshToken, type: :model do
   it { should belong_to(:user) }
 
   # バリデーション
-  it { should validate_presence_of(:token) }
+  it { should validate_presence_of(:token_digest) }
   it { should validate_presence_of(:expires_at) }
-  it { should validate_uniqueness_of(:token) }
+  it { should validate_uniqueness_of(:token_digest) }
 
   describe '.generate_for' do
     let(:user) { create(:user) }

--- a/back/spec/requests/api/v1/auth_spec.rb
+++ b/back/spec/requests/api/v1/auth_spec.rb
@@ -44,27 +44,31 @@ RSpec.describe 'Api::V1::Auths', type: :request do
     let!(:refresh_token) { RefreshToken.generate_for(user) }
 
     it '有効なリフレッシュトークンで新しいアクセストークンを返す' do
-      post '/api/v1/auth/refresh', params: { refresh_token: refresh_token.token }
+      cookies[:refresh_token] = refresh_token.token
+      post '/api/v1/auth/refresh'
       expect(response).to have_http_status(:ok)
       json = response.parsed_body
       expect(json['token']).to be_present
-      expect(json['refresh_token']).to be_present
+      expect(response.cookies['refresh_token']).to be_present
     end
 
     it '使用済みリフレッシュトークンは無効化される' do
-      post '/api/v1/auth/refresh', params: { refresh_token: refresh_token.token }
+      cookies[:refresh_token] = refresh_token.token
+      post '/api/v1/auth/refresh'
       expect(refresh_token.reload.revoked).to be true
     end
 
     it 'リフレッシュ後に新しいリフレッシュトークンが発行される' do
-      post '/api/v1/auth/refresh', params: { refresh_token: refresh_token.token }
-      json = response.parsed_body
-      expect(json['refresh_token']).not_to eq(refresh_token.token)
+      cookies[:refresh_token] = refresh_token.token
+      post '/api/v1/auth/refresh'
+      response.parsed_body
+      expect(response.cookies['refresh_token']).not_to eq(refresh_token.token)
     end
 
     it '期限切れのリフレッシュトークンで 401 を返す' do
       expired = create(:refresh_token, :expired, user: user)
-      post '/api/v1/auth/refresh', params: { refresh_token: expired.token }
+      cookies[:refresh_token] = expired.token
+      post '/api/v1/auth/refresh'
       expect(response).to have_http_status(:unauthorized)
       json = response.parsed_body
       expect(json['code']).to eq('invalid_refresh_token')
@@ -72,14 +76,16 @@ RSpec.describe 'Api::V1::Auths', type: :request do
 
     it '失効済みリフレッシュトークンで 401 を返す' do
       revoked = create(:refresh_token, :revoked, user: user)
-      post '/api/v1/auth/refresh', params: { refresh_token: revoked.token }
+      cookies[:refresh_token] = revoked.token
+      post '/api/v1/auth/refresh'
       expect(response).to have_http_status(:unauthorized)
       json = response.parsed_body
       expect(json['code']).to eq('invalid_refresh_token')
     end
 
     it '不正なリフレッシュトークンで 401 を返す' do
-      post '/api/v1/auth/refresh', params: { refresh_token: 'invalid-token' }
+      cookies[:refresh_token] = 'invalid-token'
+      post '/api/v1/auth/refresh'
       expect(response).to have_http_status(:unauthorized)
     end
 

--- a/back/spec/requests/api/v1/sessions_spec.rb
+++ b/back/spec/requests/api/v1/sessions_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe 'Api::V1::Sessions', type: :request do
         json = response.parsed_body
         expect(json['status']).to eq('success')
         expect(json['token']).to be_present
+        expect(response.cookies['refresh_token']).to be_present
         expect(json['user']).to include('id', 'email', 'username')
       end
 
@@ -46,7 +47,8 @@ RSpec.describe 'Api::V1::Sessions', type: :request do
     let!(:refresh_token) { RefreshToken.generate_for(user) }
 
     it 'ログアウト時にリフレッシュトークンを失効させる' do
-      delete '/api/v1/sessions', params: { refresh_token: refresh_token.token }
+      cookies[:refresh_token] = refresh_token.token
+      delete '/api/v1/sessions'
       expect(response).to have_http_status(:ok)
       json = response.parsed_body
       expect(json['status']).to eq('success')
@@ -59,7 +61,8 @@ RSpec.describe 'Api::V1::Sessions', type: :request do
     end
 
     it '未認証（Authorizationヘッダーなし）でもログアウトできる' do
-      delete '/api/v1/sessions', params: { refresh_token: refresh_token.token }
+      cookies[:refresh_token] = refresh_token.token
+      delete '/api/v1/sessions'
       expect(response).to have_http_status(:ok)
     end
   end

--- a/back/spec/requests/api/v1/sessions_spec.rb
+++ b/back/spec/requests/api/v1/sessions_spec.rb
@@ -65,5 +65,11 @@ RSpec.describe 'Api::V1::Sessions', type: :request do
       delete '/api/v1/sessions'
       expect(response).to have_http_status(:ok)
     end
+
+    it 'ログアウト時にリフレッシュトークンCookieが削除される' do
+      cookies[:refresh_token] = refresh_token.token
+      delete '/api/v1/sessions'
+      expect(response.cookies['refresh_token']).to be_blank
+    end
   end
 end

--- a/front/src/app/auth/callback/page.tsx
+++ b/front/src/app/auth/callback/page.tsx
@@ -15,7 +15,7 @@ function CallbackContent() {
     const handleCallback = async () => {
       try {
         const token = searchParams.get('token')
-        const refreshToken = searchParams.get('refresh_token')
+        
         const error = searchParams.get('error')
 
         if (error) {
@@ -30,7 +30,7 @@ function CallbackContent() {
           return
         }
 
-        saveAuth(token, refreshToken || undefined)
+        saveAuth(token)
         setStatus('success')
         setMessage('ログインしました。リダイレクトしています...')
         setTimeout(() => {

--- a/front/src/app/login/page.tsx
+++ b/front/src/app/login/page.tsx
@@ -42,7 +42,7 @@ export default function LoginPage() {
         throw new Error("認証トークンの取得に失敗しました")
       }
 
-      await login(responseData.token, data.email, responseData.refresh_token)
+      await login(responseData.token, data.email)
 
       toast.success("ログイン成功", { description: "ダッシュボードにリダイレクトします" })
       router.push("/dashboard")

--- a/front/src/app/register/page.tsx
+++ b/front/src/app/register/page.tsx
@@ -44,7 +44,7 @@ export default function RegisterPage() {
         throw new Error("認証トークンを取得できませんでした。もう一度お試しください。")
       }
 
-      await login(responseData.token, data.email, responseData.refresh_token)
+      await login(responseData.token, data.email)
       localStorage.setItem("tutorialSeen", "false")
 
       toast.success("登録完了", { description: "アカウントが正常に作成されました。" })

--- a/front/src/hooks/useAuth.ts
+++ b/front/src/hooks/useAuth.ts
@@ -30,21 +30,17 @@ export const useAuth = () => {
 
   // リフレッシュトークンを使ってアクセストークンを更新する
   const refreshAccessToken = async (): Promise<string | null> => {
-    const storedRefreshToken = localStorage.getItem("refreshToken");
-    if (!storedRefreshToken) return null;
-
     try {
       const response = await fetch(`${getApiUrl()}/api/v1/auth/refresh`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ refresh_token: storedRefreshToken }),
+        credentials: "include",
       });
 
       if (!response.ok) return null;
 
       const data = await response.json();
       localStorage.setItem("authToken", data.token);
-      localStorage.setItem("refreshToken", data.refresh_token);
       return data.token as string;
     } catch {
       return null;
@@ -139,12 +135,8 @@ export const useAuth = () => {
   const loginAuth = async (
     accessToken: string,
     email?: string,
-    refreshToken?: string,
   ) => {
     localStorage.setItem("authToken", accessToken);
-    if (refreshToken) {
-      localStorage.setItem("refreshToken", refreshToken);
-    }
     localStorage.setItem("isLoggedIn", "true");
     if (email) {
       localStorage.setItem("currentUserEmail", email);
@@ -157,20 +149,15 @@ export const useAuth = () => {
 
   const clearAuthStorage = () => {
     localStorage.removeItem("authToken");
-    localStorage.removeItem("refreshToken");
     localStorage.removeItem("isLoggedIn");
     localStorage.removeItem("currentUserEmail");
   };
 
   const saveAuth = (
     newToken: string,
-    newRefreshToken?: string,
     email?: string,
   ) => {
     localStorage.setItem("authToken", newToken);
-    if (newRefreshToken) {
-      localStorage.setItem("refreshToken", newRefreshToken);
-    }
     localStorage.setItem("isLoggedIn", "true");
     if (email) {
       localStorage.setItem("currentUserEmail", email);
@@ -200,23 +187,20 @@ export const useAuth = () => {
   const logout = async () => {
     try {
       const currentToken = localStorage.getItem("authToken");
-      const currentRefreshToken = localStorage.getItem("refreshToken");
 
-      if (currentRefreshToken) {
-        const headers: Record<string, string> = {
-          "Content-Type": "application/json",
-        };
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
 
-        if (currentToken) {
-          headers["Authorization"] = `Bearer ${currentToken}`;
-        }
-
-        await fetch(`${getApiUrl()}/api/v1/sessions`, {
-          method: "DELETE",
-          headers,
-          body: JSON.stringify({ refresh_token: currentRefreshToken }),
-        });
+      if (currentToken) {
+        headers["Authorization"] = `Bearer ${currentToken}`;
       }
+
+      await fetch(`${getApiUrl()}/api/v1/sessions`, {
+        method: "DELETE",
+        headers,
+        credentials: "include",
+      });
     } catch (error) {
       console.error("[Auth] ログアウトエラー:", error);
     } finally {

--- a/front/src/lib/api-client.ts
+++ b/front/src/lib/api-client.ts
@@ -12,6 +12,7 @@ type ApiRequestOptions = {
   method?: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE'
   token?: string | null
   body?: unknown
+  credentials?: RequestCredentials
 }
 
 /**
@@ -24,7 +25,7 @@ export async function apiRequest<T>(
   path: string,
   options: ApiRequestOptions = {}
 ): Promise<T | undefined> {
-  const { method = 'GET', token, body } = options
+  const { method = 'GET', token, body, credentials } = options
   const url = `${getBaseUrl()}/api/v1${path}`
 
   const headers: Record<string, string> = {}
@@ -35,6 +36,7 @@ export async function apiRequest<T>(
     method,
     headers,
     body: body !== undefined ? JSON.stringify(body) : undefined,
+    credentials,
   })
 
   if (res.status === 204) return undefined

--- a/front/src/lib/api.ts
+++ b/front/src/lib/api.ts
@@ -8,12 +8,10 @@ import type { User } from '@/types/user'
 
 type LoginResponse = {
   token: string
-  refresh_token?: string
 }
 
 type RefreshResponse = {
   token: string
-  refresh_token: string
 }
 
 type VerifyResponse = {
@@ -93,19 +91,19 @@ export const api = {
     verify: (token: string) =>
       apiRequest<VerifyResponse>('/auth/verify', { token }),
 
-    /** リフレッシュトークンを使ってアクセストークンを更新する */
-    refresh: (refreshToken: string) =>
+    /** リフレッシュトークンを使ってアクセストークンを更新する（Cookie 経由） */
+    refresh: () =>
       publicApiRequest<RefreshResponse>('/auth/refresh', {
         method: 'POST',
-        body: { refresh_token: refreshToken },
+        credentials: 'include',
       }),
 
-    /** ログアウトしてリフレッシュトークンを無効化する */
-    logout: (token: string | null, refreshToken: string) =>
-      apiRequest<void>('/auth/logout', {
-        method: 'POST',
+    /** ログアウトしてリフレッシュトークンを無効化する（Cookie 経由） */
+    logout: (token: string | null) =>
+      apiRequest<void>('/sessions', {
+        method: 'DELETE',
         token: token ?? undefined,
-        body: { refresh_token: refreshToken },
+        credentials: 'include',
       }),
   },
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要

Issue #194・#195 に対応するセキュリティ改善。リフレッシュトークンを `localStorage` から `HttpOnly Cookie` に移行し、XSS 攻撃によるトークン窃取リスクを排除する。

## 詳細な変更点

### バックエンド
- [ ] `ApplicationController` に `write_refresh_token_cookie` ヘルパーを追加（`httponly: true`, `secure`, `same_site` を適切に設定）
- [ ] ログイン・ユーザー登録・ゲストログインのレスポンスから `refresh_token` フィールドを削除し Cookie でセット
- [ ] `POST /api/v1/auth/refresh` — リクエストボディではなく Cookie からトークンを読む
- [ ] `DELETE /api/v1/sessions` — Cookie からトークンを読み、ログアウト後に Cookie を削除
- [ ] Google OAuth コールバックのリダイレクト URL から `refresh_token` クエリパラメーターを除去
- [ ] `RefreshToken.find_active_by_token` で `lock`（SELECT FOR UPDATE）を正しくモデル内で発行するよう修正
- [ ] `RefreshToken.digest` メソッドの行長違反・trailing whitespace を修正

### フロントエンド
- [ ] `useAuth.ts` — `localStorage` のリフレッシュトークン保存を全廃
- [ ] `fetch` に `credentials: 'include'` を追加してクロスオリジン Cookie を送受信
- [ ] `login/page.tsx`, `register/page.tsx` — `refresh_token` 引数を削除
- [ ] `auth/callback/page.tsx` — URL から `refresh_token` を取得する処理を削除
- [ ] `lib/api.ts` — `LoginResponse`/`RefreshResponse` の型を修正、`refresh`/`logout` を Cookie ベースに更新
- [ ] `lib/api-client.ts` — `ApiRequestOptions` に `credentials` オプションを追加

### テスト
- [ ] `auth_spec.rb` — Cookie 経由のリフレッシュトークン操作に更新（7ケース）
- [ ] `sessions_spec.rb` — Cookie 経由のログアウト操作に更新、Cookie 削除の検証テストを追加

## 修正された問題

fix #194
fix #195

<!-- I want to review in Japanese. -->