### PR TITLE
perf: フロントエンドのコンポーネント最適化（メモ化・遅延ロード）

### DIFF
--- a/front/src/app/board/_components/board-constants.ts
+++ b/front/src/app/board/_components/board-constants.ts
@@ -1,0 +1,31 @@
+export const BOARD_CATEGORIES = [
+  { value: "savings", label: "貯金のコツ" },
+  { value: "investment", label: "投資" },
+  { value: "budget", label: "予算管理" },
+  { value: "debt", label: "借金返済" },
+  { value: "income", label: "副収入" },
+  { value: "experience", label: "体験談" },
+  { value: "question", label: "質問" },
+  { value: "other", label: "その他" },
+]
+
+export const SORT_OPTIONS = [
+  { value: "latest", label: "新着順" },
+  { value: "popular", label: "人気順" },
+  { value: "comments", label: "コメント数順" },
+]
+
+export const getCategoryColor = (categoryValue: string): string => {
+  switch (categoryValue) {
+    case "savings": return "bg-blue-50 text-blue-800 border-blue-200"
+    case "investment": return "bg-green-50 text-green-800 border-green-200"
+    case "budget": return "bg-purple-50 text-purple-800 border-purple-200"
+    case "debt": return "bg-red-50 text-red-800 border-red-200"
+    case "income": return "bg-yellow-50 text-yellow-800 border-yellow-200"
+    case "experience": return "bg-teal-50 text-teal-800 border-teal-200"
+    case "question": return "bg-orange-50 text-orange-800 border-orange-200"
+    default: return "bg-cyan-50 text-cyan-800 border-cyan-200"
+  }
+}
+
+export const getUserInitial = (name: string): string => name.charAt(0).toUpperCase()

--- a/front/src/app/board/_components/comment-section.tsx
+++ b/front/src/app/board/_components/comment-section.tsx
@@ -1,0 +1,105 @@
+"use client"
+
+import React, { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { format } from "date-fns"
+import { ja } from "date-fns/locale"
+import { ThumbsUp, Send } from "lucide-react"
+import { type Comment } from "@/types/post"
+import { getUserInitial } from "./board-constants"
+
+type CommentSectionProps = {
+  comments: Comment[]
+  currentUserEmail: string
+  currentUserId?: number
+  likedCommentIds: string[]
+  onAddComment: (content: string) => Promise<void>
+  onLikeComment: (commentId: string) => void
+}
+
+function CommentSection({ comments, currentUserEmail, currentUserId, likedCommentIds, onAddComment, onLikeComment }: CommentSectionProps) {
+  const [content, setContent] = useState("")
+
+  const handleSubmit = async () => {
+    if (!content.trim()) return
+    await onAddComment(content)
+    setContent("")
+  }
+
+  return (
+    <div className="border-t pt-4">
+      <h3 className="font-medium mb-4 text-gray-900 dark:text-gray-100">
+        コメント ({comments.length})
+      </h3>
+
+      <div className="mb-4">
+        <div className="flex space-x-2">
+          <Avatar className="h-8 w-8">
+            <AvatarFallback>{getUserInitial(currentUserEmail)}</AvatarFallback>
+          </Avatar>
+          <div className="flex-1">
+            <Textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="コメントを入力..."
+              rows={3}
+              className="comment-textarea"
+            />
+            <div className="flex justify-end mt-2">
+              <Button size="sm" onClick={handleSubmit} className="bg-blue-600 hover:bg-blue-700 text-white">
+                <Send className="mr-1 h-4 w-4" />
+                投稿
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        {comments.map((comment) => {
+          const isOwnComment = comment.userId === currentUserId
+          const isCommentLiked = likedCommentIds.includes(comment.id)
+          return (
+            <div key={comment.id} className="flex space-x-2">
+              <Avatar className="h-8 w-8">
+                <AvatarFallback>{getUserInitial(comment.author)}</AvatarFallback>
+              </Avatar>
+              <div className="flex-1">
+                <div className={`rounded-lg p-3 ${isOwnComment ? "comment-own" : "comment-other"}`}>
+                  <div className="flex items-center justify-between mb-1">
+                    <span className="font-medium text-sm comment-author">
+                      {comment.author}{" "}
+                      {isOwnComment && <span className="text-xs text-blue-500">(自分)</span>}
+                    </span>
+                    <span className="text-xs comment-time">
+                      {format(new Date(comment.createdAt), "MM月dd日 HH:mm", { locale: ja })}
+                    </span>
+                  </div>
+                  <p className="text-sm comment-content">{comment.content}</p>
+                </div>
+                <div className="flex items-center mt-1">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => onLikeComment(comment.id)}
+                    className={`h-6 px-2 text-xs ${isCommentLiked ? "text-blue-600" : ""}`}
+                  >
+                    <ThumbsUp className={`mr-1 h-3 w-3 ${isCommentLiked ? "fill-blue-600 text-blue-600" : ""}`} />
+                    {comment.likes}
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )
+        })}
+        {comments.length === 0 && (
+          <p className="text-sm text-gray-600 dark:text-gray-400">まだコメントはありません。</p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default React.memo(CommentSection)

--- a/front/src/app/board/_components/create-post-modal.tsx
+++ b/front/src/app/board/_components/create-post-modal.tsx
@@ -1,0 +1,136 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Label } from "@/components/ui/label"
+import { Badge } from "@/components/ui/badge"
+import { BOARD_CATEGORIES, getCategoryColor } from "./board-constants"
+
+type CreatePostModalProps = {
+  isOpen: boolean
+  onOpenChange: (open: boolean) => void
+  onSubmit: (title: string, content: string, categories: string[]) => Promise<void>
+  initialTitle?: string
+  initialContent?: string
+  initialCategories?: string[]
+}
+
+export default function CreatePostModal({
+  isOpen,
+  onOpenChange,
+  onSubmit,
+  initialTitle = "",
+  initialContent = "",
+  initialCategories = [],
+}: CreatePostModalProps) {
+  const [title, setTitle] = useState(initialTitle)
+  const [content, setContent] = useState(initialContent)
+  const [categories, setCategories] = useState<string[]>(initialCategories)
+  const [titleError, setTitleError] = useState("")
+  const [contentError, setContentError] = useState("")
+  const [categoryError, setCategoryError] = useState("")
+
+  useEffect(() => {
+    if (isOpen) {
+      setTitle(initialTitle)
+      setContent(initialContent)
+      setCategories(initialCategories)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, initialTitle, initialContent, initialCategories.join(",")])
+
+  const toggleCategory = (category: string) => {
+    setCategories((prev) =>
+      prev.includes(category) ? prev.filter((c) => c !== category) : [...prev, category]
+    )
+  }
+
+  const handleSubmit = async () => {
+    setTitleError("")
+    setContentError("")
+    setCategoryError("")
+
+    let hasError = false
+    if (!title.trim()) { setTitleError("タイトルを入力してください。"); hasError = true }
+    if (!content.trim()) { setContentError("内容を入力してください。"); hasError = true }
+    if (categories.length === 0) { setCategoryError("カテゴリーを1つ以上選択してください。"); hasError = true }
+    if (hasError) return
+
+    await onSubmit(title, content, categories)
+    setTitle("")
+    setContent("")
+    setCategories([])
+  }
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      setTitleError("")
+      setContentError("")
+      setCategoryError("")
+    }
+    onOpenChange(open)
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-[600px] board-dialog-content">
+        <DialogHeader>
+          <DialogTitle>新規投稿</DialogTitle>
+          <DialogDescription>
+            お金の管理や貯金のコツ、投資の経験などを共有しましょう。質問も歓迎です。
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid gap-2">
+            <Label htmlFor="title">タイトル</Label>
+            <Input
+              id="title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="投稿のタイトルを入力"
+              maxLength={100}
+            />
+            {titleError && <p className="text-sm text-red-500">{titleError}</p>}
+          </div>
+        </div>
+        <div className="grid gap-2">
+          <Label>カテゴリー</Label>
+          <div className="flex flex-wrap gap-2">
+            {BOARD_CATEGORIES.map((category) => (
+              <Badge
+                key={category.value}
+                variant={categories.includes(category.value) ? "default" : "outline"}
+                className={`cursor-pointer ${categories.includes(category.value) ? getCategoryColor(category.value) : ""}`}
+                aria-pressed={categories.includes(category.value)}
+                onClick={() => toggleCategory(category.value)}
+              >
+                {category.label}
+              </Badge>
+            ))}
+          </div>
+          {categoryError && <p className="text-sm text-red-500 mt-1">{categoryError}</p>}
+          <div className="grid gap-2 mt-4">
+            <Label htmlFor="content">内容</Label>
+            <Textarea
+              id="content"
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="投稿の内容を入力"
+              rows={8}
+            />
+            {contentError && <p className="text-sm text-red-500">{contentError}</p>}
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleOpenChange(false)}>
+            キャンセル
+          </Button>
+          <Button onClick={handleSubmit} className="bg-blue-600 hover:bg-blue-700 text-white">投稿する</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/front/src/app/board/_components/edit-post-modal.tsx
+++ b/front/src/app/board/_components/edit-post-modal.tsx
@@ -1,0 +1,100 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Label } from "@/components/ui/label"
+import { Badge } from "@/components/ui/badge"
+import { type Post } from "@/types/post"
+import { BOARD_CATEGORIES, getCategoryColor } from "./board-constants"
+
+type EditPostModalProps = {
+  isOpen: boolean
+  post: Post | null
+  onOpenChange: (open: boolean) => void
+  onSubmit: (postId: string, title: string, content: string, categories: string[]) => Promise<void>
+}
+
+export default function EditPostModal({ isOpen, post, onOpenChange, onSubmit }: EditPostModalProps) {
+  const [title, setTitle] = useState("")
+  const [content, setContent] = useState("")
+  const [categories, setCategories] = useState<string[]>([])
+
+  useEffect(() => {
+    if (post) {
+      setTitle(post.title)
+      setContent(post.content)
+      setCategories([...post.category])
+    }
+  }, [post])
+
+  const toggleCategory = (category: string) => {
+    setCategories((prev) =>
+      prev.includes(category) ? prev.filter((c) => c !== category) : [...prev, category]
+    )
+  }
+
+  const handleSubmit = async () => {
+    if (!post) return
+    if (!title.trim()) { return }
+    if (!content.trim()) { return }
+    if (categories.length === 0) { return }
+    await onSubmit(post.id, title, content, categories)
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[600px] board-dialog-content">
+        <DialogHeader>
+          <DialogTitle>投稿を編集</DialogTitle>
+          <DialogDescription>投稿の内容を編集できます。</DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid gap-2">
+            <Label htmlFor="edit-title">タイトル</Label>
+            <Input
+              id="edit-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="投稿のタイトルを入力"
+              maxLength={100}
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label>カテゴリー</Label>
+            <div className="flex flex-wrap gap-2">
+              {BOARD_CATEGORIES.map((category) => (
+                <Badge
+                  key={category.value}
+                  variant={categories.includes(category.value) ? "default" : "outline"}
+                  className={`cursor-pointer ${categories.includes(category.value) ? getCategoryColor(category.value) : ""}`}
+                  onClick={() => toggleCategory(category.value)}
+                >
+                  {category.label}
+                </Badge>
+              ))}
+            </div>
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="edit-content">内容</Label>
+            <Textarea
+              id="edit-content"
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="投稿の内容を入力"
+              rows={8}
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            キャンセル
+          </Button>
+          <Button onClick={handleSubmit} className="bg-blue-600 hover:bg-blue-700 text-white">更新する</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/front/src/app/board/_components/post-card.tsx
+++ b/front/src/app/board/_components/post-card.tsx
@@ -1,0 +1,134 @@
+"use client"
+
+import React from "react"
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
+import { format } from "date-fns"
+import { ja } from "date-fns/locale"
+import { Heart, ThumbsUp, MessageCircle, MoreVertical, Edit, Trash2, Bookmark, BookmarkCheck, MessageSquare, Eye } from "lucide-react"
+import { type Post } from "@/types/post"
+import { BOARD_CATEGORIES, getCategoryColor, getUserInitial } from "./board-constants"
+
+type PostCardProps = {
+  post: Post
+  isLiked: boolean
+  isBookmarked: boolean
+  isOwner: boolean
+  onLike: (postId: string) => void
+  onBookmark: (postId: string) => void
+  onView: (post: Post) => void
+  onEdit: (post: Post) => void
+  onDeleteRequest: (postId: string) => void
+}
+
+function PostCard({ post, isLiked, isBookmarked, isOwner, onLike, onBookmark, onView, onEdit, onDeleteRequest }: PostCardProps) {
+  return (
+    <Card className="hover:shadow-md transition-shadow">
+      <CardHeader className="pb-2">
+        <div className="flex justify-between items-start">
+          <div className="flex flex-wrap gap-1 mb-2">
+            {(post.category || []).map((categoryValue) => {
+              const categoryInfo = BOARD_CATEGORIES.find((cat) => cat.value === categoryValue)
+              return (
+                <Badge
+                  key={categoryValue}
+                  variant="outline"
+                  className={`text-xs ${getCategoryColor(categoryValue)}`}
+                >
+                  {categoryInfo?.label || categoryValue}
+                </Badge>
+              )
+            })}
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="text-sm text-muted-foreground">
+              {format(new Date(post.createdAt), "yyyy年MM月dd日", { locale: ja })}
+            </div>
+            {isOwner && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" size="sm">
+                    <MoreVertical className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="board-dialog-content">
+                  <DropdownMenuItem onClick={() => onEdit(post)}>
+                    <Edit className="mr-2 h-4 w-4" />
+                    編集
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    onClick={() => onDeleteRequest(post.id)}
+                    className="text-red-600"
+                  >
+                    <Trash2 className="mr-2 h-4 w-4" />
+                    削除
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+          </div>
+        </div>
+        <CardTitle
+          className="text-xl cursor-pointer hover:text-blue-600"
+          onClick={() => onView(post)}
+        >
+          {post.title}
+        </CardTitle>
+        <div className="flex items-center mt-2">
+          <Avatar className="h-6 w-6 mr-2">
+            <AvatarFallback className="text-xs">{getUserInitial(post.author)}</AvatarFallback>
+          </Avatar>
+          <CardDescription>{post.author}</CardDescription>
+          {isOwner && (
+            <Badge variant="secondary" className="ml-2 text-xs">
+              自分の投稿
+            </Badge>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent>
+        <p className="line-clamp-3">{post.content}</p>
+      </CardContent>
+      <CardFooter className="flex justify-between pt-2">
+        <div className="flex space-x-4 text-sm text-muted-foreground">
+          <div className="flex items-center">
+            <ThumbsUp className="mr-1 h-4 w-4" />
+            <span>{post.likes}</span>
+          </div>
+          <div className="flex items-center">
+            <MessageCircle className="mr-1 h-4 w-4" />
+            <span>{post.comments}</span>
+          </div>
+          <div className="flex items-center">
+            <Eye className="mr-1 h-4 w-4" />
+            <span>{post.views}</span>
+          </div>
+        </div>
+        <div className="flex space-x-2">
+          <Button variant="ghost" size="sm" onClick={() => onLike(post.id)}>
+            <Heart className={`mr-1 h-4 w-4 ${isLiked ? "fill-red-500 text-red-500" : ""}`} />
+            いいね
+          </Button>
+          <Button variant="ghost" size="sm" onClick={() => onBookmark(post.id)}>
+            {isBookmarked ? (
+              <BookmarkCheck className="mr-1 h-4 w-4 text-blue-600" />
+            ) : (
+              <Bookmark className="mr-1 h-4 w-4" />
+            )}
+            ブックマーク
+          </Button>
+          <Button variant="ghost" size="sm" onClick={() => onView(post)}>
+            <MessageSquare className="mr-1 h-4 w-4" />
+            詳細
+          </Button>
+        </div>
+      </CardFooter>
+    </Card>
+  )
+}
+
+export default React.memo(PostCard)

--- a/front/src/app/board/_components/post-detail-dialog.tsx
+++ b/front/src/app/board/_components/post-detail-dialog.tsx
@@ -1,0 +1,87 @@
+"use client"
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Badge } from "@/components/ui/badge"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { format } from "date-fns"
+import { ja } from "date-fns/locale"
+import { type Post, type Comment } from "@/types/post"
+import { BOARD_CATEGORIES, getCategoryColor, getUserInitial } from "./board-constants"
+import CommentSection from "./comment-section"
+
+type PostDetailDialogProps = {
+  post: Post | null
+  isOpen: boolean
+  comments: Comment[]
+  currentUserEmail: string
+  currentUserId?: number
+  likedCommentIds: string[]
+  onOpenChange: (open: boolean) => void
+  onAddComment: (content: string) => Promise<void>
+  onLikeComment: (commentId: string) => void
+}
+
+export default function PostDetailDialog({
+  post,
+  isOpen,
+  comments,
+  currentUserEmail,
+  currentUserId,
+  likedCommentIds,
+  onOpenChange,
+  onAddComment,
+  onLikeComment,
+}: PostDetailDialogProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[800px] max-h-[80vh] overflow-y-auto board-dialog-content">
+        {post && (
+          <>
+            <DialogHeader>
+              <div className="flex flex-wrap gap-1 mb-2">
+                {post.category.map((categoryValue) => {
+                  const categoryInfo = BOARD_CATEGORIES.find((cat) => cat.value === categoryValue)
+                  return (
+                    <Badge
+                      key={categoryValue}
+                      variant="outline"
+                      className={`text-xs ${getCategoryColor(categoryValue)}`}
+                    >
+                      {categoryInfo?.label || categoryValue}
+                    </Badge>
+                  )
+                })}
+              </div>
+              <DialogTitle className="text-xl text-primary dark:text-primary-dark">{post.title}</DialogTitle>
+              <div className="flex items-center">
+                <Avatar className="h-8 w-8 mr-2">
+                  <AvatarFallback>{getUserInitial(post.author)}</AvatarFallback>
+                </Avatar>
+                <div>
+                  <p className="font-medium text-gray-900 dark:text-gray-100">{post.author}</p>
+                  <p className="text-sm text-gray-600 dark:text-gray-300">
+                    {format(new Date(post.createdAt), "yyyy年MM月dd日 HH:mm", { locale: ja })}
+                  </p>
+                </div>
+              </div>
+            </DialogHeader>
+
+            <div className="py-4">
+              <div className="whitespace-pre-wrap text-gray-800 dark:text-gray-100 mb-6">
+                {post.content}
+              </div>
+              <CommentSection
+                comments={comments}
+                currentUserEmail={currentUserEmail}
+                currentUserId={currentUserId}
+                likedCommentIds={likedCommentIds}
+                onAddComment={onAddComment}
+                onLikeComment={onLikeComment}
+              />
+            </div>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/front/src/app/board/_components/post-list.tsx
+++ b/front/src/app/board/_components/post-list.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import React from "react"
+import { Button } from "@/components/ui/button"
+import { MessageSquare, Loader2 } from "lucide-react"
+import { type Post } from "@/types/post"
+import PostCard from "./post-card"
+
+type PostListProps = {
+  posts: Post[]
+  isLoading: boolean
+  likedPostIds: string[]
+  bookmarkedPostIds: string[]
+  currentUserId?: number
+  onLike: (postId: string) => void
+  onBookmark: (postId: string) => void
+  onView: (post: Post) => void
+  onEdit: (post: Post) => void
+  onDeleteRequest: (postId: string) => void
+  onCreatePost: () => void
+}
+
+function PostList({
+  posts,
+  isLoading,
+  likedPostIds,
+  bookmarkedPostIds,
+  currentUserId,
+  onLike,
+  onBookmark,
+  onView,
+  onEdit,
+  onDeleteRequest,
+  onCreatePost,
+}: PostListProps) {
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-10">
+        <Loader2 className="h-8 w-8 animate-spin text-blue-600" />
+      </div>
+    )
+  }
+
+  if (posts.length === 0) {
+    return (
+      <div className="text-center py-10">
+        <MessageSquare className="mx-auto h-12 w-12 text-muted-foreground opacity-50" />
+        <h3 className="mt-4 text-lg font-medium">投稿がありません</h3>
+        <p className="mt-2 text-muted-foreground">検索条件に一致する投稿がないか、まだ投稿がありません。</p>
+        <Button className="mt-4 text-white bg-blue-400 hover:bg-blue-600" onClick={onCreatePost}>
+          最初の投稿を作成
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {posts.map((post) => (
+        <PostCard
+          key={post.id}
+          post={post}
+          isLiked={likedPostIds.includes(post.id)}
+          isBookmarked={bookmarkedPostIds.includes(post.id)}
+          isOwner={post.userId === currentUserId}
+          onLike={onLike}
+          onBookmark={onBookmark}
+          onView={onView}
+          onEdit={onEdit}
+          onDeleteRequest={onDeleteRequest}
+        />
+      ))}
+    </div>
+  )
+}
+
+export default React.memo(PostList)

--- a/front/src/app/board/page.tsx
+++ b/front/src/app/board/page.tsx
@@ -1,45 +1,25 @@
 "use client"
 
-import { useState, useEffect, useCallback } from "react"
+import { useState, useEffect, useCallback, useRef } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Badge } from "@/components/ui/badge"
-import { Avatar, AvatarFallback } from "@/components/ui/avatar"
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Textarea } from "@/components/ui/textarea"
 import { Label } from "@/components/ui/label"
-import { format } from "date-fns"
-import { ja } from "date-fns/locale"
-import { MessageSquare, Heart, Search, Filter, Plus, ThumbsUp, MessageCircle, MoreVertical, Edit, Trash2, Bookmark, BookmarkCheck, Send, Eye, Loader2 } from "lucide-react"
+import { Search, Filter, Plus, Loader2 } from "lucide-react"
 import { toast } from "sonner"
 import { useAuth } from "@/hooks/useAuth"
 import { api } from "@/lib/api"
 import { mapApiPost, mapApiComment, type Post, type Comment } from "@/types/post"
-
-// 掲示板カテゴリー
-const BOARD_CATEGORIES = [
-  { value: "savings", label: "貯金のコツ" },
-  { value: "investment", label: "投資" },
-  { value: "budget", label: "予算管理" },
-  { value: "debt", label: "借金返済" },
-  { value: "income", label: "副収入" },
-  { value: "experience", label: "体験談" },
-  { value: "question", label: "質問" },
-  { value: "other", label: "その他" },
-]
-
-// ソートオプション
-const SORT_OPTIONS = [
-  { value: "latest", label: "新着順" },
-  { value: "popular", label: "人気順" },
-  { value: "comments", label: "コメント数順" },
-]
+import { BOARD_CATEGORIES, SORT_OPTIONS, getCategoryColor } from "./_components/board-constants"
+import PostList from "./_components/post-list"
+import PostDetailDialog from "./_components/post-detail-dialog"
+import CreatePostModal from "./_components/create-post-modal"
+import EditPostModal from "./_components/edit-post-modal"
 
 export default function BoardPage() {
   const router = useRouter()
@@ -70,19 +50,15 @@ export default function BoardPage() {
   const [sortOption, setSortOption] = useState("latest")
   const [selectedCategories, setSelectedCategories] = useState<string[]>([])
 
-  // 新規投稿の状態
-  const [newPostTitle, setNewPostTitle] = useState("")
-  const [newPostContent, setNewPostContent] = useState("")
-  const [newPostCategories, setNewPostCategories] = useState<string[]>([])
-  const [newCommentContent, setNewCommentContent] = useState("")
-  const [titleError, setTitleError] = useState("")
-  const [contentError, setContentError] = useState("")
-  const [categoryError, setCategoryError] = useState("")
-
-  // 編集・削除対象の投稿
+  // 操作対象の投稿
   const [editingPost, setEditingPost] = useState<Post | null>(null)
   const [deletingPostId, setDeletingPostId] = useState<string | null>(null)
   const [selectedPost, setSelectedPost] = useState<Post | null>(null)
+
+  // 実績シェアの初期値
+  const [shareInitialTitle, setShareInitialTitle] = useState("")
+  const [shareInitialContent, setShareInitialContent] = useState("")
+  const [shareInitialCategories, setShareInitialCategories] = useState<string[]>([])
 
   // 認証チェック
   useEffect(() => {
@@ -92,11 +68,13 @@ export default function BoardPage() {
   }, [authIsLoading, isAuthenticated, router])
 
   // 実績シェアのクエリパラメータ処理
+  const hasProcessedShareParams = useRef(false)
   useEffect(() => {
     const shareTitle = searchParams.get("shareTitle")
     const shareTier = searchParams.get("shareTier")
-    if (!shareTitle) return
+    if (!shareTitle || hasProcessedShareParams.current) return
 
+    hasProcessedShareParams.current = true
     const tierLabel: Record<string, string> = {
       bronze: "ブロンズ",
       silver: "シルバー",
@@ -106,14 +84,12 @@ export default function BoardPage() {
     const tier = shareTier ? (tierLabel[shareTier] ?? shareTier) : null
     const tierTag = tier ? ` #${tier}` : ""
 
-    setNewPostTitle(`「${shareTitle}」を達成しました！`)
-    setNewPostContent(`「${shareTitle}」を達成しました！🦦${tierTag}\n\n`)
-    setNewPostCategories(["experience"])
+    setShareInitialTitle(`「${shareTitle}」を達成しました！`)
+    setShareInitialContent(`「${shareTitle}」を達成しました！🦦${tierTag}\n\n`)
+    setShareInitialCategories(["experience"])
     setIsNewPostDialogOpen(true)
   }, [searchParams])
 
-  // 投稿一覧を取得
-  // 投稿一覧を取得（page=1 でリセット）
   const fetchPosts = useCallback(async () => {
     if (!token) return
     setIsPostsLoading(true)
@@ -134,7 +110,6 @@ export default function BoardPage() {
     }
   }, [token])
 
-  // 追加読み込み
   const handleLoadMore = async () => {
     if (!token || isLoadingMore || currentPage >= totalPages) return
     setIsLoadingMore(true)
@@ -168,24 +143,19 @@ export default function BoardPage() {
     }
   }, [isAuthenticated, token, fetchPosts])
 
-  // いいねの処理
-  const handleLike = async (postId: string) => {
+  const handleLike = useCallback(async (postId: string) => {
     if (!token) return
     const isCurrentlyLiked = likedPostIds.includes(postId)
-
     try {
       if (isCurrentlyLiked) {
         await api.posts.unlike(token, postId)
-      } else {
-        await api.posts.like(token, postId)
-      }
-      if (isCurrentlyLiked) {
         setLikedPostIds((prev) => prev.filter((id) => id !== postId))
         setPosts((prev) =>
           prev.map((post) => (post.id === postId ? { ...post, likes: Math.max(0, post.likes - 1) } : post))
         )
         toast.success("いいねを取り消しました")
       } else {
+        await api.posts.like(token, postId)
         setLikedPostIds((prev) => [...prev, postId])
         setPosts((prev) =>
           prev.map((post) => (post.id === postId ? { ...post, likes: post.likes + 1 } : post))
@@ -195,12 +165,10 @@ export default function BoardPage() {
     } catch {
       toast.error("操作に失敗しました")
     }
-  }
+  }, [token, likedPostIds])
 
-  // 投稿のフィルタリングとソート
   const filterAndSortPosts = useCallback(() => {
     let filtered = [...posts]
-
     if (searchTerm) {
       const term = searchTerm.toLowerCase()
       filtered = filtered.filter(
@@ -213,17 +181,14 @@ export default function BoardPage() {
           )
       )
     }
-
     if (activeTab !== "all") {
       filtered = filtered.filter((post) => post.category.includes(activeTab))
     }
-
     if (selectedCategories.length > 0) {
       filtered = filtered.filter((post) =>
         post.category.some((category) => selectedCategories.includes(category))
       )
     }
-
     switch (sortOption) {
       case "latest":
         filtered.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
@@ -238,21 +203,13 @@ export default function BoardPage() {
     setFilteredPosts(filtered)
   }, [posts, searchTerm, activeTab, selectedCategories, sortOption])
 
-  const toggleCategory = (category: string) => {
-    setNewPostCategories((prev) =>
-      prev.includes(category) ? prev.filter((c) => c !== category) : [...prev, category]
-    )
-  }
-
   useEffect(() => {
     filterAndSortPosts()
   }, [filterAndSortPosts])
 
-  // ブックマークの切り替え
-  const toggleBookmark = async (postId: string) => {
+  const toggleBookmark = useCallback(async (postId: string) => {
     if (!token) return
     const isBookmarked = bookmarkedPosts.includes(postId)
-
     try {
       if (isBookmarked) {
         await api.posts.unbookmark(token, postId)
@@ -266,146 +223,103 @@ export default function BoardPage() {
     } catch {
       toast.error("操作に失敗しました")
     }
-  }
+  }, [token, bookmarkedPosts])
 
-  // 新規投稿
-  const handleAddPost = async () => {
-    setTitleError("")
-    setContentError("")
-    setCategoryError("")
-
-    let hasError = false
-    if (!newPostTitle.trim()) { setTitleError("タイトルを入力してください。"); hasError = true }
-    if (!newPostContent.trim()) { setContentError("内容を入力してください。"); hasError = true }
-    if (newPostCategories.length === 0) { setCategoryError("カテゴリーを1つ以上選択してください。"); hasError = true }
-    if (hasError || !token) return
-
+  const handleAddPost = useCallback(async (title: string, content: string, categories: string[]) => {
+    if (!token) return
     try {
       const newPost = await api.posts.create(token, {
-        title: newPostTitle,
-        content: newPostContent,
-        category_names: newPostCategories,
+        title,
+        content,
+        category_names: categories,
       })
       if (newPost) {
         setPosts((prev) => [mapApiPost(newPost), ...prev])
       }
-      setNewPostTitle("")
-      setNewPostContent("")
-      setNewPostCategories([])
       setIsNewPostDialogOpen(false)
       toast.success("投稿が完了しました", { description: "あなたの投稿が掲示板に追加されました。" })
     } catch {
       toast.error("投稿の作成に失敗しました")
     }
-  }
+  }, [token])
 
-  // 投稿の編集を開始
-  const handleEditPost = (post: Post) => {
+  const handleEditPost = useCallback((post: Post) => {
     setEditingPost(post)
-    setNewPostTitle(post.title)
-    setNewPostContent(post.content)
-    setNewPostCategories([...post.category])
     setIsEditPostDialogOpen(true)
-  }
+  }, [])
 
-  // 投稿の編集を保存
-  const handleSaveEdit = async () => {
-    if (!editingPost || !token) return
-
-    let hasError = false
-    if (!newPostTitle.trim()) { toast.error("タイトルが入力されていません"); hasError = true }
-    if (!newPostContent.trim()) { toast.error("内容が入力されていません"); hasError = true }
-    if (newPostCategories.length === 0) { toast.error("カテゴリーが選択されていません"); hasError = true }
-    if (hasError) return
-
+  const handleSaveEdit = useCallback(async (postId: string, title: string, content: string, categories: string[]) => {
+    if (!token) return
     try {
-      const updated = await api.posts.update(token, editingPost.id, {
-        title: newPostTitle,
-        content: newPostContent,
-        category_names: newPostCategories,
+      const updated = await api.posts.update(token, postId, {
+        title,
+        content,
+        category_names: categories,
       })
       if (updated) {
-        setPosts((prev) => prev.map((p) => (p.id === editingPost.id ? mapApiPost(updated) : p)))
+        setPosts((prev) => prev.map((p) => (p.id === postId ? mapApiPost(updated) : p)))
       }
-      setNewPostTitle("")
-      setNewPostContent("")
-      setNewPostCategories([])
       setEditingPost(null)
       setIsEditPostDialogOpen(false)
       toast.success("投稿を更新しました")
     } catch {
       toast.error("投稿の更新に失敗しました")
     }
-  }
+  }, [token])
 
-  // 投稿詳細を表示＋コメント取得
-  const handleViewPost = async (post: Post) => {
+  const handleViewPost = useCallback(async (post: Post) => {
     setSelectedPost(post)
     setIsPostDetailDialogOpen(true)
-
-    // 閲覧数を増加
-    if (token) {
-      try {
-        await api.posts.incrementViews(token, post.id)
-        setPosts((prev) => prev.map((p) => (p.id === post.id ? { ...p, views: p.views + 1 } : p)))
-      } catch { /* 閲覧数エラーは無視 */ }
-
-      // コメント取得
-      try {
-        const data = await api.posts.comments.list(token, post.id)
-        if (data) {
-          setComments((prev) => [
-            ...prev.filter((c) => c.postId !== post.id),
-            ...data.map(mapApiComment),
-          ])
-        }
-      } catch (err) {
-        console.error("コメント取得エラー:", err)
+    if (!token) return
+    try {
+      await api.posts.incrementViews(token, post.id)
+      setPosts((prev) => prev.map((p) => (p.id === post.id ? { ...p, views: p.views + 1 } : p)))
+    } catch { /* 閲覧数エラーは無視 */ }
+    try {
+      const data = await api.posts.comments.list(token, post.id)
+      if (data) {
+        setComments((prev) => [
+          ...prev.filter((c) => c.postId !== post.id),
+          ...data.map(mapApiComment),
+        ])
       }
+    } catch (err) {
+      console.error("コメント取得エラー:", err)
     }
-  }
+  }, [token])
 
-  // コメントを追加
-  const handleAddComment = async () => {
-    if (!selectedPost || !newCommentContent.trim() || !token) {
+  const handleAddComment = useCallback(async (content: string) => {
+    if (!selectedPost || !token) {
       toast.error("コメント内容を入力してください")
       return
     }
-
     try {
-      const newComment = await api.posts.comments.create(token, selectedPost.id, newCommentContent)
+      const newComment = await api.posts.comments.create(token, selectedPost.id, content)
       if (newComment) {
         setComments((prev) => [...prev, mapApiComment(newComment)])
         setPosts((prev) =>
           prev.map((p) => (p.id === selectedPost.id ? { ...p, comments: p.comments + 1 } : p))
         )
       }
-      setNewCommentContent("")
       toast.success("コメントを投稿しました")
     } catch {
       toast.error("コメントの投稿に失敗しました")
     }
-  }
+  }, [selectedPost, token])
 
-  // コメントにいいね
-  const handleLikeComment = async (commentId: string) => {
+  const handleLikeComment = useCallback(async (commentId: string) => {
     if (!selectedPost || !token) return
     const isCurrentlyLiked = likedCommentIds.includes(commentId)
-
     try {
       if (isCurrentlyLiked) {
         await api.posts.comments.unlike(token, selectedPost.id, commentId)
-      } else {
-        await api.posts.comments.like(token, selectedPost.id, commentId)
-      }
-
-      if (isCurrentlyLiked) {
         setLikedCommentIds((prev) => prev.filter((id) => id !== commentId))
         setComments((prev) =>
           prev.map((c) => (c.id === commentId ? { ...c, likes: Math.max(0, c.likes - 1) } : c))
         )
         toast.success("コメントのいいねを取り消しました")
       } else {
+        await api.posts.comments.like(token, selectedPost.id, commentId)
         setLikedCommentIds((prev) => [...prev, commentId])
         setComments((prev) =>
           prev.map((c) => (c.id === commentId ? { ...c, likes: c.likes + 1 } : c))
@@ -415,18 +329,15 @@ export default function BoardPage() {
     } catch {
       toast.error("操作に失敗しました")
     }
-  }
+  }, [selectedPost, token, likedCommentIds])
 
-  const getPostComments = (postId: string) => {
-    return comments
+  const getPostComments = (postId: string): Comment[] =>
+    comments
       .filter((comment) => comment.postId === postId)
       .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
-  }
 
-  // 投稿の削除
   const handleDeletePost = async () => {
     if (!deletingPostId || !token) return
-
     try {
       await api.posts.delete(token, deletingPostId)
       setPosts((prev) => prev.filter((post) => post.id !== deletingPostId))
@@ -438,181 +349,14 @@ export default function BoardPage() {
     }
   }
 
-  const openDeleteDialog = (postId: string) => {
+  const openDeleteDialog = useCallback((postId: string) => {
     setDeletingPostId(postId)
     setIsDeleteDialogOpen(true)
-  }
+  }, [])
 
-  const isPostOwner = (post: Post) => post.userId === user?.id
-
-  const getUserInitial = (name: string) => name.charAt(0).toUpperCase()
-
-  const getCategoryColor = (categoryValue: string) => {
-    switch (categoryValue) {
-      case "savings": return "bg-blue-50 text-blue-800 border-blue-200"
-      case "investment": return "bg-green-50 text-green-800 border-green-200"
-      case "budget": return "bg-purple-50 text-purple-800 border-purple-200"
-      case "debt": return "bg-red-50 text-red-800 border-red-200"
-      case "income": return "bg-yellow-50 text-yellow-800 border-yellow-200"
-      case "experience": return "bg-teal-50 text-teal-800 border-teal-200"
-      case "question": return "bg-orange-50 text-orange-800 border-orange-200"
-      default: return "bg-cyan-50 text-cyan-800 border-cyan-200"
-    }
-  }
-
-  const handleNewPostDialogChange = (open: boolean) => {
-    setIsNewPostDialogOpen(open)
-    if (!open) {
-      setTitleError("")
-      setContentError("")
-      setCategoryError("")
-    }
-  }
-
-  const handleEditPostDialogChange = (open: boolean) => {
+  const handleEditModalClose = (open: boolean) => {
     setIsEditPostDialogOpen(open)
-    if (!open) {
-      setTitleError("")
-      setContentError("")
-      setCategoryError("")
-      setEditingPost(null)
-    }
-  }
-
-  // 投稿リストのレンダリング
-  const renderPostList = (postsToRender: Post[]) => {
-    if (isPostsLoading) {
-      return (
-        <div className="flex justify-center py-10">
-          <Loader2 className="h-8 w-8 animate-spin text-blue-600" />
-        </div>
-      )
-    }
-
-    if (postsToRender.length === 0) {
-      return (
-        <div className="text-center py-10">
-          <MessageSquare className="mx-auto h-12 w-12 text-muted-foreground opacity-50" />
-          <h3 className="mt-4 text-lg font-medium">投稿がありません</h3>
-          <p className="mt-2 text-muted-foreground">検索条件に一致する投稿がないか、まだ投稿がありません。</p>
-          <Button className="mt-4 text-white bg-blue-400 hover:bg-blue-600" onClick={() => setIsNewPostDialogOpen(true)}>
-            最初の投稿を作成
-          </Button>
-        </div>
-      )
-    }
-
-    return (
-      <div className="space-y-4">
-        {postsToRender.map((post) => {
-          const isLiked = likedPostIds.includes(post.id)
-          return (
-            <Card key={post.id} className="hover:shadow-md transition-shadow">
-              <CardHeader className="pb-2">
-                <div className="flex justify-between items-start">
-                  <div className="flex flex-wrap gap-1 mb-2">
-                    {(post.category || []).map((categoryValue) => {
-                      const categoryInfo = BOARD_CATEGORIES.find((cat) => cat.value === categoryValue)
-                      return (
-                        <Badge
-                          key={categoryValue}
-                          variant="outline"
-                          className={`text-xs ${getCategoryColor(categoryValue)}`}
-                        >
-                          {categoryInfo?.label || categoryValue}
-                        </Badge>
-                      )
-                    })}
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <div className="text-sm text-muted-foreground">
-                      {format(new Date(post.createdAt), "yyyy年MM月dd日", { locale: ja })}
-                    </div>
-                    {isPostOwner(post) && (
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <Button variant="ghost" size="sm">
-                            <MoreVertical className="h-4 w-4" />
-                          </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end" className="board-dialog-content">
-                          <DropdownMenuItem onClick={() => handleEditPost(post)}>
-                            <Edit className="mr-2 h-4 w-4" />
-                            編集
-                          </DropdownMenuItem>
-                          <DropdownMenuSeparator />
-                          <DropdownMenuItem
-                            onClick={() => openDeleteDialog(post.id)}
-                            className="text-red-600"
-                          >
-                            <Trash2 className="mr-2 h-4 w-4" />
-                            削除
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    )}
-                  </div>
-                </div>
-                <CardTitle
-                  className="text-xl cursor-pointer hover:text-blue-600"
-                  onClick={() => handleViewPost(post)}
-                >
-                  {post.title}
-                </CardTitle>
-                <div className="flex items-center mt-2">
-                  <Avatar className="h-6 w-6 mr-2">
-                    <AvatarFallback className="text-xs">{getUserInitial(post.author)}</AvatarFallback>
-                  </Avatar>
-                  <CardDescription>{post.author}</CardDescription>
-                  {isPostOwner(post) && (
-                    <Badge variant="secondary" className="ml-2 text-xs">
-                      自分の投稿
-                    </Badge>
-                  )}
-                </div>
-              </CardHeader>
-              <CardContent>
-                <p className="line-clamp-3">{post.content}</p>
-              </CardContent>
-              <CardFooter className="flex justify-between pt-2">
-                <div className="flex space-x-4 text-sm text-muted-foreground">
-                  <div className="flex items-center">
-                    <ThumbsUp className="mr-1 h-4 w-4" />
-                    <span>{post.likes}</span>
-                  </div>
-                  <div className="flex items-center">
-                    <MessageCircle className="mr-1 h-4 w-4" />
-                    <span>{post.comments}</span>
-                  </div>
-                  <div className="flex items-center">
-                    <Eye className="mr-1 h-4 w-4" />
-                    <span>{post.views}</span>
-                  </div>
-                </div>
-                <div className="flex space-x-2">
-                  <Button variant="ghost" size="sm" onClick={() => handleLike(post.id)}>
-                    <Heart className={`mr-1 h-4 w-4 ${isLiked ? "fill-red-500 text-red-500" : ""}`} />
-                    いいね
-                  </Button>
-                  <Button variant="ghost" size="sm" onClick={() => toggleBookmark(post.id)}>
-                    {bookmarkedPosts.includes(post.id) ? (
-                      <BookmarkCheck className="mr-1 h-4 w-4 text-blue-600" />
-                    ) : (
-                      <Bookmark className="mr-1 h-4 w-4" />
-                    )}
-                    ブックマーク
-                  </Button>
-                  <Button variant="ghost" size="sm" onClick={() => handleViewPost(post)}>
-                    <MessageSquare className="mr-1 h-4 w-4" />
-                    詳細
-                  </Button>
-                </div>
-              </CardFooter>
-            </Card>
-          )
-        })}
-      </div>
-    )
+    if (!open) setEditingPost(null)
   }
 
   if (authIsLoading) {
@@ -685,12 +429,36 @@ export default function BoardPage() {
         </TabsList>
 
         <TabsContent value="all" className="mt-6">
-          {renderPostList(filteredPosts)}
+          <PostList
+            posts={filteredPosts}
+            isLoading={isPostsLoading}
+            likedPostIds={likedPostIds}
+            bookmarkedPostIds={bookmarkedPosts}
+            currentUserId={user?.id}
+            onLike={handleLike}
+            onBookmark={toggleBookmark}
+            onView={handleViewPost}
+            onEdit={handleEditPost}
+            onDeleteRequest={openDeleteDialog}
+            onCreatePost={() => setIsNewPostDialogOpen(true)}
+          />
         </TabsContent>
 
         {BOARD_CATEGORIES.map((category) => (
           <TabsContent key={category.value} value={category.value} className="mt-6">
-            {renderPostList(filteredPosts)}
+            <PostList
+              posts={filteredPosts}
+              isLoading={isPostsLoading}
+              likedPostIds={likedPostIds}
+              bookmarkedPostIds={bookmarkedPosts}
+              currentUserId={user?.id}
+              onLike={handleLike}
+              onBookmark={toggleBookmark}
+              onView={handleViewPost}
+              onEdit={handleEditPost}
+              onDeleteRequest={openDeleteDialog}
+              onCreatePost={() => setIsNewPostDialogOpen(true)}
+            />
           </TabsContent>
         ))}
 
@@ -713,234 +481,36 @@ export default function BoardPage() {
         )}
       </Tabs>
 
-      {/* 新規投稿ダイアログ */}
-      <Dialog open={isNewPostDialogOpen} onOpenChange={handleNewPostDialogChange}>
-        <DialogContent className="sm:max-w-[600px] board-dialog-content">
-          <DialogHeader>
-            <DialogTitle>新規投稿</DialogTitle>
-            <DialogDescription>
-              お金の管理や貯金のコツ、投資の経験などを共有しましょう。質問も歓迎です。
-            </DialogDescription>
-          </DialogHeader>
-          <div className="grid gap-4 py-4">
-            <div className="grid gap-2">
-              <Label htmlFor="title">タイトル</Label>
-              <Input
-                id="title"
-                value={newPostTitle}
-                onChange={(e) => setNewPostTitle(e.target.value)}
-                placeholder="投稿のタイトルを入力"
-                maxLength={100}
-              />
-              {titleError && <p className="text-sm text-red-500">{titleError}</p>}
-            </div>
-          </div>
-          <div className="grid gap-2">
-            <Label>カテゴリー</Label>
-            <div className="flex flex-wrap gap-2">
-              {BOARD_CATEGORIES.map((category) => (
-                <Badge
-                  key={category.value}
-                  variant={newPostCategories.includes(category.value) ? "default" : "outline"}
-                  className={`cursor-pointer ${newPostCategories.includes(category.value) ? getCategoryColor(category.value) : ""}`}
-                  aria-pressed={newPostCategories.includes(category.value)}
-                  onClick={() => toggleCategory(category.value)}
-                >
-                  {category.label}
-                </Badge>
-              ))}
-            </div>
-            {categoryError && <p className="text-sm text-red-500 mt-1">{categoryError}</p>}
-            <div className="grid gap-2 mt-4">
-              <Label htmlFor="content">内容</Label>
-              <Textarea
-                id="content"
-                value={newPostContent}
-                onChange={(e) => setNewPostContent(e.target.value)}
-                placeholder="投稿の内容を入力"
-                rows={8}
-              />
-              {contentError && <p className="text-sm text-red-500">{contentError}</p>}
-            </div>
-          </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => handleNewPostDialogChange(false)}>
-              キャンセル
-            </Button>
-            <Button onClick={handleAddPost} className="bg-blue-600 hover:bg-blue-700 text-white">投稿する</Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      {/* 新規投稿モーダル */}
+      <CreatePostModal
+        isOpen={isNewPostDialogOpen}
+        onOpenChange={setIsNewPostDialogOpen}
+        onSubmit={handleAddPost}
+        initialTitle={shareInitialTitle}
+        initialContent={shareInitialContent}
+        initialCategories={shareInitialCategories}
+      />
 
-      {/* 編集ダイアログ */}
-      <Dialog open={isEditPostDialogOpen} onOpenChange={handleEditPostDialogChange}>
-        <DialogContent className="sm:max-w-[600px] board-dialog-content">
-          <DialogHeader>
-            <DialogTitle>投稿を編集</DialogTitle>
-            <DialogDescription>投稿の内容を編集できます。</DialogDescription>
-          </DialogHeader>
-          <div className="grid gap-4 py-4">
-            <div className="grid gap-2">
-              <Label htmlFor="edit-title">タイトル</Label>
-              <Input
-                id="edit-title"
-                value={newPostTitle}
-                onChange={(e) => setNewPostTitle(e.target.value)}
-                placeholder="投稿のタイトルを入力"
-                maxLength={100}
-              />
-            </div>
-            <div className="grid gap-2">
-              <Label>カテゴリー</Label>
-              <div className="flex flex-wrap gap-2">
-                {BOARD_CATEGORIES.map((category) => (
-                  <Badge
-                    key={category.value}
-                    variant={newPostCategories.includes(category.value) ? "default" : "outline"}
-                    className={`cursor-pointer ${newPostCategories.includes(category.value) ? getCategoryColor(category.value) : ""}`}
-                    onClick={() => toggleCategory(category.value)}
-                  >
-                    {category.label}
-                  </Badge>
-                ))}
-              </div>
-            </div>
-            <div className="grid gap-2">
-              <Label htmlFor="edit-content">内容</Label>
-              <Textarea
-                id="edit-content"
-                value={newPostContent}
-                onChange={(e) => setNewPostContent(e.target.value)}
-                placeholder="投稿の内容を入力"
-                rows={8}
-              />
-            </div>
-          </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setIsEditPostDialogOpen(false)}>
-              キャンセル
-            </Button>
-            <Button onClick={handleSaveEdit} className="bg-blue-600 hover:bg-blue-700 text-white">更新する</Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      {/* 編集モーダル */}
+      <EditPostModal
+        isOpen={isEditPostDialogOpen}
+        post={editingPost}
+        onOpenChange={handleEditModalClose}
+        onSubmit={handleSaveEdit}
+      />
 
       {/* 投稿詳細ダイアログ */}
-      <Dialog open={isPostDetailDialogOpen} onOpenChange={setIsPostDetailDialogOpen}>
-        <DialogContent className="sm:max-w-[800px] max-h-[80vh] overflow-y-auto board-dialog-content">
-          {selectedPost && (
-            <>
-              <DialogHeader>
-                <div className="flex flex-wrap gap-1 mb-2">
-                  {selectedPost.category.map((categoryValue) => {
-                    const categoryInfo = BOARD_CATEGORIES.find((cat) => cat.value === categoryValue)
-                    return (
-                      <Badge
-                        key={categoryValue}
-                        variant="outline"
-                        className={`text-xs ${getCategoryColor(categoryValue)}`}
-                      >
-                        {categoryInfo?.label || categoryValue}
-                      </Badge>
-                    )
-                  })}
-                </div>
-                <DialogTitle className="text-xl text-primary dark:text-primary-dark">{selectedPost.title}</DialogTitle>
-                <div className="flex items-center">
-                  <Avatar className="h-8 w-8 mr-2">
-                    <AvatarFallback>{getUserInitial(selectedPost.author)}</AvatarFallback>
-                  </Avatar>
-                  <div>
-                    <p className="font-medium text-gray-900 dark:text-gray-100">{selectedPost.author}</p>
-                    <p className="text-sm text-gray-600 dark:text-gray-300">
-                      {format(new Date(selectedPost.createdAt), "yyyy年MM月dd日 HH:mm", { locale: ja })}
-                    </p>
-                  </div>
-                </div>
-              </DialogHeader>
-
-              <div className="py-4">
-                <div className="whitespace-pre-wrap text-gray-800 dark:text-gray-100 mb-6">
-                  {selectedPost.content}
-                </div>
-
-                {/* コメントセクション */}
-                <div className="border-t pt-4">
-                  <h3 className="font-medium mb-4 text-gray-900 dark:text-gray-100">
-                    コメント ({getPostComments(selectedPost.id).length})
-                  </h3>
-
-                  <div className="mb-4">
-                    <div className="flex space-x-2">
-                      <Avatar className="h-8 w-8">
-                        <AvatarFallback>{getUserInitial(user?.email || "")}</AvatarFallback>
-                      </Avatar>
-                      <div className="flex-1">
-                        <Textarea
-                          value={newCommentContent}
-                          onChange={(e) => setNewCommentContent(e.target.value)}
-                          placeholder="コメントを入力..."
-                          rows={3}
-                          className="comment-textarea"
-                        />
-                        <div className="flex justify-end mt-2">
-                          <Button size="sm" onClick={handleAddComment} className="bg-blue-600 hover:bg-blue-700 text-white">
-                            <Send className="mr-1 h-4 w-4" />
-                            投稿
-                          </Button>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* コメント一覧 */}
-                  <div className="space-y-4">
-                    {getPostComments(selectedPost.id).map((comment) => {
-                      const isOwnComment = comment.userId === user?.id
-                      const isCommentLiked = likedCommentIds.includes(comment.id)
-                      return (
-                        <div key={comment.id} className="flex space-x-2">
-                          <Avatar className="h-8 w-8">
-                            <AvatarFallback>{getUserInitial(comment.author)}</AvatarFallback>
-                          </Avatar>
-                          <div className="flex-1">
-                            <div className={`rounded-lg p-3 ${isOwnComment ? "comment-own" : "comment-other"}`}>
-                              <div className="flex items-center justify-between mb-1">
-                                <span className="font-medium text-sm comment-author">
-                                  {comment.author}{" "}
-                                  {isOwnComment && <span className="text-xs text-blue-500">(自分)</span>}
-                                </span>
-                                <span className="text-xs comment-time">
-                                  {format(new Date(comment.createdAt), "MM月dd日 HH:mm", { locale: ja })}
-                                </span>
-                              </div>
-                              <p className="text-sm comment-content">{comment.content}</p>
-                            </div>
-                            <div className="flex items-center mt-1">
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => handleLikeComment(comment.id)}
-                                className={`h-6 px-2 text-xs ${isCommentLiked ? "text-blue-600" : ""}`}
-                              >
-                                <ThumbsUp className={`mr-1 h-3 w-3 ${isCommentLiked ? "fill-blue-600 text-blue-600" : ""}`} />
-                                {comment.likes}
-                              </Button>
-                            </div>
-                          </div>
-                        </div>
-                      )
-                    })}
-                    {getPostComments(selectedPost.id).length === 0 && (
-                      <p className="text-sm text-gray-600 dark:text-gray-400">まだコメントはありません。</p>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </>
-          )}
-        </DialogContent>
-      </Dialog>
+      <PostDetailDialog
+        post={selectedPost}
+        isOpen={isPostDetailDialogOpen}
+        comments={selectedPost ? getPostComments(selectedPost.id) : []}
+        currentUserEmail={user?.email || ""}
+        currentUserId={user?.id}
+        likedCommentIds={likedCommentIds}
+        onOpenChange={setIsPostDetailDialogOpen}
+        onAddComment={handleAddComment}
+        onLikeComment={handleLikeComment}
+      />
 
       {/* 削除確認ダイアログ */}
       <AlertDialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>

--- a/front/src/app/dashboard/page.tsx
+++ b/front/src/app/dashboard/page.tsx
@@ -34,9 +34,26 @@ import {
   DollarSign,
   Loader2,
 } from "lucide-react"
+import dynamic from "next/dynamic"
 import OtterAnimation from "@/components/otter-animation"
-import ExpensePieChart from "@/components/expense-pie-chart"
-import MonthlyTrend from "@/components/monthly-trend"
+
+const ExpensePieChart = dynamic(() => import("@/components/expense-pie-chart"), {
+  ssr: false,
+  loading: () => (
+    <div className="flex items-center justify-center h-full">
+      <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+    </div>
+  ),
+})
+
+const MonthlyTrend = dynamic(() => import("@/components/monthly-trend"), {
+  ssr: false,
+  loading: () => (
+    <div className="flex items-center justify-center h-full">
+      <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+    </div>
+  ),
+})
 import { Tutorial } from "@/components/tutorial"
 import {
   AlertDialog,

--- a/front/src/components/expense-pie-chart.tsx
+++ b/front/src/components/expense-pie-chart.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from 'recharts';
 
 type Transaction = {
@@ -35,7 +36,7 @@ const getCategoryLabel = (categoryValue: string) => {
   return category ? category.label : categoryValue;
 };
 
-export default function ExpensePieChart({ transactions }: ExpensePieChartProps) {
+function ExpensePieChart({ transactions }: ExpensePieChartProps) {
   const expenseData = transactions
     .filter(t => t.type === 'expense')
     .reduce((acc, transaction) => {
@@ -76,3 +77,5 @@ export default function ExpensePieChart({ transactions }: ExpensePieChartProps) 
     </ResponsiveContainer>
   );
 }
+
+export default React.memo(ExpensePieChart)

--- a/front/src/components/monthly-trend.tsx
+++ b/front/src/components/monthly-trend.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 import { useTheme } from "next-themes"
 import { format, subMonths, startOfMonth, endOfMonth, parseISO } from "date-fns"
 import { ja } from "date-fns/locale"
@@ -28,7 +29,7 @@ type MonthlyTrendProps = {
   transactions: Transaction[]
 }
 
-export default function MonthlyTrend({ transactions }: MonthlyTrendProps) {
+function MonthlyTrend({ transactions }: MonthlyTrendProps) {
   const { theme } = useTheme()
 
   const today = new Date()
@@ -80,7 +81,7 @@ export default function MonthlyTrend({ transactions }: MonthlyTrendProps) {
     return [`${typeof value === 'number' ? value.toLocaleString() : String(value ?? '')} 円`, String(name ?? '')];
   }
 
-  const legendFormatter = (value: string, _entry: any, _index: number) => {
+  const legendFormatter = (value: string) => {
     if (value === "income") return "収入"
     if (value === "expense") return "支出"
     if (value === "balance") return "収支"
@@ -142,3 +143,4 @@ export default function MonthlyTrend({ transactions }: MonthlyTrendProps) {
     </ResponsiveContainer>
   )
 }
+export default React.memo(MonthlyTrend)


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要

Issue #164 に対応するフロントエンドパフォーマンス改善。

## 詳細な変更点

### board/page.tsx のコンポーネント分割
- [ ] 1003行の単一ファイルを `_components/` 配下に分割し 573行（43%削減）に整理
- [ ] `board-constants.ts` — カテゴリ定数・ソートオプション・ユーティリティ関数を集約
- [ ] `post-card.tsx` — 投稿カード（`React.memo` 適用）
- [ ] `post-list.tsx` — 投稿リスト・ローディング・空状態（`React.memo` 適用）
- [ ] `comment-section.tsx` — コメント入力・一覧（`React.memo` 適用、コメント入力 state を内部管理）
- [ ] `post-detail-dialog.tsx` — 投稿詳細ダイアログ
- [ ] `create-post-modal.tsx` — 新規投稿モーダル（タイトル・内容・カテゴリ state を内部管理）
- [ ] `edit-post-modal.tsx` — 編集モーダル（同上）

### React.memo + useCallback による再レンダリング抑制
- [ ] `page.tsx` の全コールバックを `useCallback` でラップして `React.memo` の効果を最大化
- [ ] `expense-pie-chart.tsx`・`monthly-trend.tsx` に `React.memo` を適用

### Recharts の遅延ロード
- [ ] `dashboard/page.tsx` のチャート 2 本を `next/dynamic（ssr: false）` で遅延ロードし初期バンドルサイズを削減

## 修正された問題

fix #164

<!-- I want to review in Japanese. -->