### PR TITLE
fix: JWTシークレットキーの管理をJsonWebTokenサービスに一元化する

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,6 @@
 npx lint-staged
+
+# フロントエンドの変更がある場合のみ型チェックを実行
+if git diff --cached --name-only | grep -q '^front/'; then
+  cd front && npm run type-check
+fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+cd front && npm run lint && npm run type-check

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -5,25 +5,6 @@ class ApplicationController < ActionController::API
 
   before_action :authorize_request
 
-  def encode_token(payload)
-    JWT.encode(payload, ENV['JWT_SECRET'] || 'my_secret')
-  end
-
-  def auth_header
-    request.headers['Authorization']
-  end
-
-  def decoded_token
-    return unless auth_header
-
-    token = auth_header.split[1]
-    begin
-      JWT.decode(token, ENV['JWT_SECRET'] || 'my_secret', true, algorithm: 'HS256')
-    rescue JWT::DecodeError
-      nil
-    end
-  end
-
   attr_reader :current_user
 
   def logged_in?

--- a/back/app/services/json_web_token.rb
+++ b/back/app/services/json_web_token.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 class JsonWebToken
-  SECRET_KEY = Rails.application.credentials.secret_key_base || Rails.application.secrets.secret_key_base
+  HMAC_SECRET = ENV.fetch('JWT_SECRET') { Rails.application.credentials.secret_key_base }
 
   def self.encode(payload, exp = 30.minutes.from_now)
     payload[:exp] = exp.to_i
-    JWT.encode(payload, SECRET_KEY)
+    JWT.encode(payload, HMAC_SECRET)
   end
 
   def self.decode(token)
     raise JWT::DecodeError, 'Token is nil' if token.nil?
 
-    decoded = JWT.decode(token, SECRET_KEY)[0]
+    decoded = JWT.decode(token, HMAC_SECRET)[0]
     ActiveSupport::HashWithIndifferentAccess.new decoded
   rescue JWT::ExpiredSignature
     raise JWT::ExpiredSignature, 'Token has expired'


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要

- JWTシークレットキーの参照を`JsonWebToken`サービスに一本化した
- `ApplicationController`のハードコードされた`'my_secret'`フォールバックを削除した

## 詳細な変更点

- [x] `JsonWebToken::SECRET_KEY`を`HMAC_SECRET = ENV.fetch('JWT_SECRET') { Rails.application.credentials.secret_key_base }`に変更
- [x] `ApplicationController`の`encode_token`・`decoded_token`メソッドを削除（`ENV['JWT_SECRET'] || 'my_secret'`参照を除去）
- [x] `authorize_request`は元々`JsonWebToken.decode`を使っていたため変更なし
- [x] Huskyのpre-pushフック追加・pre-commitに型チェックを追加（chore）

## 修正された問題

fixes #167

<!-- I want to review in Japanese. -->