### PR TITLE
refactor: posts・commentsテーブルの冗長なauthor列を削除する

### DIFF
--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -123,9 +123,10 @@ module Api
       end
 
       def optional_current_user
-        return nil unless auth_header
+        header = request.headers['Authorization']
+        return nil unless header
 
-        token = auth_header.split.last
+        token = header.split.last
         decoded = JsonWebToken.decode(token)
         User.find_by(id: decoded[:user_id])
       rescue StandardError

--- a/back/db/migrate/20260605141950_remove_author_from_posts_and_comments.rb
+++ b/back/db/migrate/20260605141950_remove_author_from_posts_and_comments.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RemoveAuthorFromPostsAndComments < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :posts, :author, :string
+    remove_column :comments, :author, :string
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_01_234704) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_05_141950) do
   create_table "achievements", force: :cascade do |t|
     t.integer "category", default: 0, null: false
     t.datetime "created_at", null: false
@@ -52,7 +52,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_234704) do
   end
 
   create_table "comments", force: :cascade do |t|
-    t.string "author"
     t.text "content"
     t.datetime "created_at", null: false
     t.integer "likes_count"
@@ -107,7 +106,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_234704) do
   end
 
   create_table "posts", force: :cascade do |t|
-    t.string "author"
     t.integer "comments_count"
     t.text "content"
     t.datetime "created_at", null: false

--- a/back/spec/requests/api/v1/posts_spec.rb
+++ b/back/spec/requests/api/v1/posts_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe 'Api::V1::Posts', type: :request do
       get '/api/v1/posts'
       expect(response).to have_http_status(:ok)
       json = response.parsed_body
-      expect(json).to be_an(Array)
-      expect(json.length).to eq(3)
+      expect(json['posts']).to be_an(Array)
+      expect(json['posts'].length).to eq(3)
     end
 
     it '認証なしでも一覧を取得できる' do
@@ -26,7 +26,7 @@ RSpec.describe 'Api::V1::Posts', type: :request do
     it 'レスポンスに必要なフィールドが含まれる' do
       get '/api/v1/posts', headers: headers
       json = response.parsed_body
-      post_data = json.first
+      post_data = json['posts'].first
       expect(post_data).to include('id', 'title', 'content', 'author', 'likes_count', 'comments_count', 'views_count',
                                    'liked_by_me', 'bookmarked_by_me')
     end
@@ -37,7 +37,7 @@ RSpec.describe 'Api::V1::Posts', type: :request do
 
       get '/api/v1/posts', headers: headers
       json = response.parsed_body
-      liked_post = json.find { |p| p['id'] == post_record.id }
+      liked_post = json['posts'].find { |p| p['id'] == post_record.id }
       expect(liked_post['liked_by_me']).to be true
     end
   end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要

Issue #275 の対応。`posts` および `comments` テーブルの冗長な `author` 列（string型）を削除する。
コントローラーは既に `user&.username` で動的に取得しているためDB列は不要。

## 詳細な変更点

- [x] マイグレーション `RemoveAuthorFromPostsAndComments` を作成・実行（`posts.author`・`comments.author` を削除）
- [x] `posts_spec.rb` をページネーション対応レスポンス形式（`{ posts: [...], meta: {...} }`）に更新
- [x] `optional_current_user` の `auth_header` 未定義バグを修正（`request.headers['Authorization']` に変更）

## 修正された問題

fix #275

<!-- I want to review in Japanese. -->