### PR TITLE
fix: OAuthコールバックページでリフレッシュトークンを正しく保存する

### DIFF
--- a/back/app/controllers/api/v1/auth_controller.rb
+++ b/back/app/controllers/api/v1/auth_controller.rb
@@ -3,7 +3,9 @@
 module Api
   module V1
     class AuthController < ApplicationController
-      skip_before_action :authorize_request, only: %i[google google_callback auth_failure verify refresh]
+      def skip_authorization?
+        action_name.in?(%w[google google_callback auth_failure verify refresh])
+      end
 
       # Googleログインへのリダイレクト
       def google
@@ -21,7 +23,7 @@ module Api
           # フロントエンドへリダイレクト（トークンを含む）
           write_refresh_token_cookie(refresh_token.token)
           callback_url = "#{ENV.fetch('FRONTEND_URL', nil)}/auth/callback?token=#{token}"
-          redirect_to callback_url
+          redirect_to callback_url, allow_other_host: true
         else
           render json: { error: 'OAuth認証に失敗しました' }, status: :unprocessable_content
         end
@@ -58,14 +60,14 @@ module Api
               name: @current_user.name
             }, status: :ok
           rescue JWT::ExpiredSignature
-            render json: { error: 'Token has expired', code: 'token_expired' }, status: :unauthorized
+            render json: { error: 'トークンの有効期限が切れています', code: 'token_expired' }, status: :unauthorized
           rescue JWT::DecodeError => e
-            render json: { error: 'Invalid token', code: 'invalid_token', details: e.message }, status: :unauthorized
+            render json: { error: '無効なトークンです', code: 'invalid_token', details: e.message }, status: :unauthorized
           rescue ActiveRecord::RecordNotFound
-            render json: { error: 'User not found', code: 'user_not_found' }, status: :unauthorized
+            render json: { error: 'ユーザーが見つかりません', code: 'user_not_found' }, status: :unauthorized
           end
         else
-          render json: { error: 'Authorization header missing', code: 'missing_header' }, status: :unauthorized
+          render json: { error: 'Authorizationヘッダーがありません', code: 'missing_header' }, status: :unauthorized
         end
       end
 

--- a/back/spec/requests/api/v1/auth_spec.rb
+++ b/back/spec/requests/api/v1/auth_spec.rb
@@ -98,6 +98,60 @@ RSpec.describe 'Api::V1::Auths', type: :request do
   end
 
   describe 'GET /api/v1/auth/google/callback' do
-    pending "Google OAuth のテストは別途実装 #{__FILE__}"
+    let(:user) { create(:user) }
+    let(:auth_hash) do
+      OmniAuth::AuthHash.new(
+        provider: 'google_oauth2',
+        uid: '123456789',
+        info: {
+          email: user.email,
+          name: user.username,
+          first_name: user.username
+        },
+        credentials: {
+          token: 'mock_google_token',
+          expires_at: 1.week.from_now.to_i
+        }
+      )
+    end
+
+    before do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with('FRONTEND_URL', nil).and_return('http://localhost:3001')
+    end
+
+    context 'OAuth認証成功時' do
+      before do
+        allow(User).to receive(:find_or_create_from_oauth).and_return(user)
+      end
+
+      it 'フロントエンドのコールバックURLにリダイレクトする' do
+        get '/api/v1/auth/google/callback', env: { 'omniauth.auth' => auth_hash }
+        expect(response).to have_http_status(:redirect)
+        expect(response.headers['Location']).to include('/auth/callback?token=')
+      end
+
+      it 'リフレッシュトークンをHttpOnly Cookieにセットする' do
+        get '/api/v1/auth/google/callback', env: { 'omniauth.auth' => auth_hash }
+        expect(response.cookies['refresh_token']).to be_present
+      end
+
+      it 'DBにリフレッシュトークンが作成される' do
+        expect do
+          get '/api/v1/auth/google/callback', env: { 'omniauth.auth' => auth_hash }
+        end.to change(RefreshToken, :count).by(1)
+      end
+    end
+
+    context 'OAuth認証失敗時（ユーザー取得・作成不可）' do
+      before do
+        allow(User).to receive(:find_or_create_from_oauth).and_return(nil)
+      end
+
+      it '422 を返す' do
+        get '/api/v1/auth/google/callback', env: { 'omniauth.auth' => auth_hash }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
   end
 end

--- a/front/src/app/auth/callback/page.tsx
+++ b/front/src/app/auth/callback/page.tsx
@@ -7,7 +7,7 @@ import { useAuth } from '@/hooks/useAuth'
 function CallbackContent() {
   const searchParams = useSearchParams()
   const router = useRouter()
-  const { saveAuth } = useAuth()
+  const { login } = useAuth()
   const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading')
   const [message, setMessage] = useState('')
 
@@ -15,7 +15,7 @@ function CallbackContent() {
     const handleCallback = async () => {
       try {
         const token = searchParams.get('token')
-        
+
         const error = searchParams.get('error')
 
         if (error) {
@@ -30,7 +30,7 @@ function CallbackContent() {
           return
         }
 
-        saveAuth(token)
+        await login(token)
         setStatus('success')
         setMessage('ログインしました。リダイレクトしています...')
         setTimeout(() => {


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要

OAuth コールバックページ（`auth/callback/page.tsx`）で `saveAuth` を使っていたため、アクセストークンが localStorage に保存されるものの `user` state が設定されず、通常ログインと挙動が異なっていた。`login`（`loginAuth`）に変更することで `checkAuthWithToken` が呼ばれ、user state が正しく初期化されるようにした。

## 詳細な変更点

- [x] **フロント** `auth/callback/page.tsx`: `saveAuth(token)` → `await login(token)` に変更（user state を checkAuthWithToken 経由で設定）
- [x] **バックエンド** `auth_controller.rb`: `google_callback` の `redirect_to` に `allow_other_host: true` を追加（Rails 7+ のクロスホストリダイレクト対応）
- [x] **バックエンド** `auth_controller.rb`: `skip_before_action` → `skip_authorization?` オーバーライドに変更（backend.md 規約準拠）
- [x] **バックエンド** `auth_controller.rb`: `verify` アクションのエラーメッセージを日本語化（backend.md 規約準拠）
- [x] **テスト** `auth_spec.rb`: pending だった `google_callback` スペックを実装（リダイレクト・Cookie・DB への RefreshToken 作成・失敗時 422 を検証）

## 修正された問題

- fix #231

<!-- I want to review in Japanese. -->