### PR TITLE
fix: showアクションのliked_by_me未取得とエラーメッセージの情報漏洩を修正する

### DIFF
--- a/back/app/controllers/api/v1/achievements_controller.rb
+++ b/back/app/controllers/api/v1/achievements_controller.rb
@@ -43,7 +43,7 @@ module Api
       end
 
       def show
-        achievement = @current_user.achievements.find(params[:id])
+        achievement = @current_user.achievements.find(params.expect(:id))
         render json: {
           achievement: {
             id: achievement.id,
@@ -87,7 +87,7 @@ module Api
               tier: achievement.tier
             }, status: :ok
           else
-            render json: { errors: achievement.errors.full_messages }, status: :unprocessable_entity
+            render json: { errors: achievement.errors.full_messages }, status: :unprocessable_content
           end
         else
           render json: { error: 'Achievement not found' }, status: :not_found

--- a/back/app/controllers/api/v1/bookmarks_controller.rb
+++ b/back/app/controllers/api/v1/bookmarks_controller.rb
@@ -9,14 +9,14 @@ module Api
         bookmark = @post.bookmarks.new(user: current_api_v1_user)
 
         if @post.bookmarks.exists?(user: current_api_v1_user)
-          render json: { errors: ['すでにブックマーク済みです'] }, status: :unprocessable_entity
+          render json: { errors: ['すでにブックマーク済みです'] }, status: :unprocessable_content
           return
         end
 
         if bookmark.save
           render json: { message: 'Post bookmarked' }, status: :created
         else
-          render json: { errors: bookmark.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: bookmark.errors.full_messages }, status: :unprocessable_content
         end
       end
 
@@ -34,7 +34,7 @@ module Api
       private
 
       def set_post
-        @post = Post.find(params[:post_id])
+        @post = Post.find(params.expect(:post_id))
       rescue ActiveRecord::RecordNotFound
         render json: { error: '投稿が見つかりません' }, status: :not_found
       end

--- a/back/app/controllers/api/v1/comments_controller.rb
+++ b/back/app/controllers/api/v1/comments_controller.rb
@@ -24,7 +24,7 @@ module Api
           @post.increment!(:comments_count)
           render json: comment_json(@comment), status: :created
         else
-          render json: { errors: @comment.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: @comment.errors.full_messages }, status: :unprocessable_content
         end
       end
 
@@ -37,7 +37,7 @@ module Api
         if @comment.update(comment_params)
           render json: comment_json(@comment)
         else
-          render json: { errors: @comment.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: @comment.errors.full_messages }, status: :unprocessable_content
         end
       end
 
@@ -55,13 +55,13 @@ module Api
       private
 
       def set_post
-        @post = Post.find(params[:post_id])
+        @post = Post.find(params.expect(:post_id))
       rescue ActiveRecord::RecordNotFound
         render json: { error: '投稿が見つかりません' }, status: :not_found
       end
 
       def set_comment
-        @comment = @post.comments.find(params[:id])
+        @comment = @post.comments.find(params.expect(:id))
       rescue ActiveRecord::RecordNotFound
         render json: { error: 'コメントが見つかりません' }, status: :not_found
       end

--- a/back/app/controllers/api/v1/contacts_controller.rb
+++ b/back/app/controllers/api/v1/contacts_controller.rb
@@ -13,7 +13,7 @@ module Api
           ContactMailer.confirmation(@contact).deliver_later
           render json: { message: 'お問い合わせを受け付けました。' }, status: :created
         else
-          render json: { errors: @contact.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: @contact.errors.full_messages }, status: :unprocessable_content
         end
       end
 

--- a/back/app/controllers/api/v1/likes_controller.rb
+++ b/back/app/controllers/api/v1/likes_controller.rb
@@ -4,21 +4,21 @@ module Api
   module V1
     class LikesController < ApplicationController
       def create_post_like
-        post = Post.find(params[:id])
+        post = Post.find(params.expect(:id))
         like = post.likes.new(user: current_api_v1_user)
 
         if like.save
           post.increment!(:likes_count)
           render json: { message: 'Post liked', likes_count: post.likes_count }, status: :created
         else
-          render json: { errors: like.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: like.errors.full_messages }, status: :unprocessable_content
         end
       rescue ActiveRecord::RecordNotFound
         render json: { error: '投稿が見つかりません' }, status: :not_found
       end
 
       def destroy_post_like
-        post = Post.find(params[:id])
+        post = Post.find(params.expect(:id))
         like = post.likes.find_by(user: current_api_v1_user)
 
         if like
@@ -33,7 +33,7 @@ module Api
       end
 
       def create_comment_like
-        comment = Comment.find(params[:id])
+        comment = Comment.find(params.expect(:id))
         like = comment.likes.new(user: current_api_v1_user)
 
         if like.save
@@ -41,14 +41,14 @@ module Api
           render json: { message: 'Comment liked', likes_count: comment.likes_count },
                  status: :created
         else
-          render json: { errors: like.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: like.errors.full_messages }, status: :unprocessable_content
         end
       rescue ActiveRecord::RecordNotFound
         render json: { error: 'コメントが見つかりません' }, status: :not_found
       end
 
       def destroy_comment_like
-        comment = Comment.find(params[:id])
+        comment = Comment.find(params.expect(:id))
         like = comment.likes.find_by(user: current_api_v1_user)
 
         if like

--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -3,7 +3,6 @@
 module Api
   module V1
     class PostsController < ApplicationController
-      before_action :authenticate_user!, except: %i[index show increment_views]
       before_action :set_post_with_associations, only: %i[show update]
       before_action :set_post, only: %i[destroy increment_views]
 
@@ -44,7 +43,15 @@ module Api
       end
 
       def show
-        render json: post_json(@post)
+        viewer = optional_current_user
+        liked_ids = if viewer
+                      Like.where(likeable_type: 'Post', likeable_id: @post.id,
+                                 user: viewer).pluck(:likeable_id).to_set
+                    else
+                      [].to_set
+                    end
+        bookmarked_ids = viewer ? Bookmark.where(post_id: @post.id, user: viewer).pluck(:post_id).to_set : [].to_set
+        render json: post_json(@post, liked_ids: liked_ids, bookmarked_ids: bookmarked_ids)
       end
 
       def create

--- a/back/app/controllers/api/v1/savings_goals_controller.rb
+++ b/back/app/controllers/api/v1/savings_goals_controller.rb
@@ -15,7 +15,7 @@ module Api
         if @savings_goal.save
           render json: @savings_goal, status: :created
         else
-          render json: { errors: @savings_goal.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: @savings_goal.errors.full_messages }, status: :unprocessable_content
         end
       end
 
@@ -23,7 +23,7 @@ module Api
         if @savings_goal.update(savings_goal_params)
           render json: @savings_goal
         else
-          render json: { errors: @savings_goal.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: @savings_goal.errors.full_messages }, status: :unprocessable_content
         end
       end
 
@@ -35,7 +35,7 @@ module Api
       private
 
       def set_savings_goal
-        @savings_goal = @current_user.savings_goals.find(params[:id])
+        @savings_goal = @current_user.savings_goals.find(params.expect(:id))
       rescue ActiveRecord::RecordNotFound
         render json: { error: '貯金目標が見つかりません' }, status: :not_found
       end

--- a/back/app/controllers/api/v1/transactions_controller.rb
+++ b/back/app/controllers/api/v1/transactions_controller.rb
@@ -38,7 +38,7 @@ module Api
           update_achievements_for_transaction(@transaction)
           render json: @transaction, status: :created
         else
-          render json: { errors: @transaction.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: @transaction.errors.full_messages }, status: :unprocessable_content
         end
       end
 
@@ -47,7 +47,7 @@ module Api
           update_achievements_for_transaction(@transaction)
           render json: @transaction
         else
-          render json: { errors: @transaction.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: @transaction.errors.full_messages }, status: :unprocessable_content
         end
       end
 
@@ -61,7 +61,7 @@ module Api
       private
 
       def set_transaction
-        @transaction = current_api_v1_user.transactions.find(params[:id])
+        @transaction = current_api_v1_user.transactions.find(params.expect(:id))
       rescue ActiveRecord::RecordNotFound
         render json: { error: '取引が見つかりません' }, status: :not_found
       end

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -50,21 +50,21 @@ class ApplicationController < ActionController::API
           Rails.logger.info "Current user set: #{Rails.env.development? ? @current_user.id : '[MASKED]'}"
         else
           Rails.logger.error 'Invalid token payload' if Rails.env.development?
-          render json: { error: 'Invalid token payload' }, status: :unauthorized
+          render json: { error: 'トークンのペイロードが無効です' }, status: :unauthorized
         end
       else
         Rails.logger.error 'Authorization token not provided' if Rails.env.development?
-        render json: { error: 'Authorization token not provided' }, status: :unauthorized
+        render json: { error: '認証トークンが指定されていません' }, status: :unauthorized
       end
     rescue ActiveRecord::RecordNotFound => e
       Rails.logger.error "User not found: #{Rails.env.development? ? e.message : '[MASKED]'}"
-      render json: { error: "User not found: #{e.message}" }, status: :unauthorized
+      render json: { error: 'ユーザーが見つかりません' }, status: :unauthorized
     rescue JWT::ExpiredSignature => e
       Rails.logger.error "Token has expired: #{Rails.env.development? ? e.message : '[MASKED]'}"
-      render json: { error: "Token has expired: #{e.message}" }, status: :unauthorized
+      render json: { error: 'トークンの有効期限が切れています' }, status: :unauthorized
     rescue JWT::DecodeError => e
       Rails.logger.error "Invalid token: #{Rails.env.development? ? e.message : '[MASKED]'}"
-      render json: { error: "Invalid token: #{e.message}" }, status: :unauthorized
+      render json: { error: '無効なトークンです' }, status: :unauthorized
     end
   end
 

--- a/back/app/controllers/concerns/exception_handler.rb
+++ b/back/app/controllers/concerns/exception_handler.rb
@@ -11,7 +11,7 @@ module ExceptionHandler
     end
 
     rescue_from ActiveRecord::RecordInvalid do |e|
-      render json: { error: e.message }, status: :unprocessable_entity
+      render json: { error: e.message }, status: :unprocessable_content
     end
 
     rescue_from ExceptionHandler::InvalidToken do |e|

--- a/back/db/migrate/20260320000000_add_unique_index_to_oauth_providers.rb
+++ b/back/db/migrate/20260320000000_add_unique_index_to_oauth_providers.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 class AddUniqueIndexToOauthProviders < ActiveRecord::Migration[7.1]
   def change
-    add_index :oauth_providers, [:provider, :uid], unique: true
+    add_index :oauth_providers, %i[provider uid], unique: true
   end
 end

--- a/back/spec/requests/api/v1/achievements_spec.rb
+++ b/back/spec/requests/api/v1/achievements_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Api::V1::Achievements', type: :request do
       expect(response).to have_http_status(:ok)
       json = response.parsed_body
       expect(json['achievements']).to be_an(Array)
-      expect(json['achievements'].map { |a| a['id'] }).to match_array([unlocked_achievement.id, locked_achievement.id])
+      expect(json['achievements'].pluck('id')).to match_array([unlocked_achievement.id, locked_achievement.id])
       expect(json['summary']).to include('total_achievements', 'unlocked_achievements')
       expect(json['summary']['total_achievements']).to eq(json['achievements'].length)
     end

--- a/back/spec/requests/api/v1/posts_spec.rb
+++ b/back/spec/requests/api/v1/posts_spec.rb
@@ -57,6 +57,27 @@ RSpec.describe 'Api::V1::Posts', type: :request do
       get '/api/v1/posts/0'
       expect(response).to have_http_status(:not_found)
     end
+
+    it '認証済みユーザーはliked_by_meが正しく返る' do
+      create(:like, user: user, likeable: post_record)
+      get "/api/v1/posts/#{post_record.id}", headers: headers
+      json = response.parsed_body
+      expect(json['liked_by_me']).to be true
+    end
+
+    it '認証済みユーザーはbookmarked_by_meが正しく返る' do
+      create(:bookmark, user: user, post: post_record)
+      get "/api/v1/posts/#{post_record.id}", headers: headers
+      json = response.parsed_body
+      expect(json['bookmarked_by_me']).to be true
+    end
+
+    it '未認証ユーザーはliked_by_meとbookmarked_by_meがfalseになる' do
+      get "/api/v1/posts/#{post_record.id}"
+      json = response.parsed_body
+      expect(json['liked_by_me']).to be false
+      expect(json['bookmarked_by_me']).to be false
+    end
   end
 
   describe 'POST /api/v1/posts' do


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要

`GET /api/v1/posts/:id` で `liked_by_me` / `bookmarked_by_me` が常に `false` を返していたバグと、`ApplicationController` のエラーレスポンスに `e.message` を直接含めていたセキュリティ問題を修正しました。あわせて RuboCop の自動修正（非推奨警告対応）も適用しています。

## 詳細な変更点

- [x] `PostsController#show` で `optional_current_user` から viewer を取得し、`liked_ids` / `bookmarked_ids` を `post_json` に渡すよう修正
- [x] `PostsController` の冗長な `before_action :authenticate_user!` を削除（`authorize_request` + `skip_authorization?` で既に制御済み）
- [x] `ApplicationController#authorize_request` の rescue / else ブロック全 4 箇所で `e.message` をレスポンスに直接含めていた問題を修正し、日本語の固定メッセージに変更
- [x] `GET /api/v1/posts/:id` に `liked_by_me` / `bookmarked_by_me` の true / false 両ケースのスペックを追加
- [x] `:unprocessable_entity` → `:unprocessable_content`（Rack 非推奨警告対応）
- [x] `params[:id]` → `params.expect(:id)`（Rails 8 スタイルに統一）

## 修正された問題

バグレビューで発見した問題の修正（issue 番号なし）

<!-- I want to review in Japanese. -->