### PR TITLE
feat: 貯金マイルストーンとコミュニティ実績を追加する

### DIFF
--- a/back/.rubocop.yml
+++ b/back/.rubocop.yml
@@ -35,6 +35,8 @@ Metrics/PerceivedComplexity:
 
 Metrics/ClassLength:
   Max: 300
+  Exclude:
+    - 'app/services/**/*'
 
 # スペック・ルーティングファイルのブロック長制限を緩和
 Metrics/BlockLength:

--- a/back/app/controllers/api/v1/achievements_controller.rb
+++ b/back/app/controllers/api/v1/achievements_controller.rb
@@ -43,7 +43,7 @@ module Api
       end
 
       def show
-        achievement = @current_user.achievements.find(params[:id])
+        achievement = @current_user.achievements.find(params.expect(:id))
         render json: {
           achievement: {
             id: achievement.id,
@@ -87,7 +87,7 @@ module Api
               tier: achievement.tier
             }, status: :ok
           else
-            render json: { errors: achievement.errors.full_messages }, status: :unprocessable_entity
+            render json: { errors: achievement.errors.full_messages }, status: :unprocessable_content
           end
         else
           render json: { error: 'Achievement not found' }, status: :not_found

--- a/back/app/controllers/api/v1/bookmarks_controller.rb
+++ b/back/app/controllers/api/v1/bookmarks_controller.rb
@@ -9,14 +9,14 @@ module Api
         bookmark = @post.bookmarks.new(user: current_api_v1_user)
 
         if @post.bookmarks.exists?(user: current_api_v1_user)
-          render json: { errors: ['すでにブックマーク済みです'] }, status: :unprocessable_entity
+          render json: { errors: ['すでにブックマーク済みです'] }, status: :unprocessable_content
           return
         end
 
         if bookmark.save
           render json: { message: 'Post bookmarked' }, status: :created
         else
-          render json: { errors: bookmark.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: bookmark.errors.full_messages }, status: :unprocessable_content
         end
       end
 
@@ -34,7 +34,7 @@ module Api
       private
 
       def set_post
-        @post = Post.find(params[:post_id])
+        @post = Post.find(params.expect(:post_id))
       rescue ActiveRecord::RecordNotFound
         render json: { error: '投稿が見つかりません' }, status: :not_found
       end

--- a/back/app/controllers/api/v1/comments_controller.rb
+++ b/back/app/controllers/api/v1/comments_controller.rb
@@ -24,7 +24,7 @@ module Api
           @post.increment!(:comments_count)
           render json: comment_json(@comment), status: :created
         else
-          render json: { errors: @comment.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: @comment.errors.full_messages }, status: :unprocessable_content
         end
       end
 
@@ -37,7 +37,7 @@ module Api
         if @comment.update(comment_params)
           render json: comment_json(@comment)
         else
-          render json: { errors: @comment.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: @comment.errors.full_messages }, status: :unprocessable_content
         end
       end
 
@@ -55,13 +55,13 @@ module Api
       private
 
       def set_post
-        @post = Post.find(params[:post_id])
+        @post = Post.find(params.expect(:post_id))
       rescue ActiveRecord::RecordNotFound
         render json: { error: '投稿が見つかりません' }, status: :not_found
       end
 
       def set_comment
-        @comment = @post.comments.find(params[:id])
+        @comment = @post.comments.find(params.expect(:id))
       rescue ActiveRecord::RecordNotFound
         render json: { error: 'コメントが見つかりません' }, status: :not_found
       end

--- a/back/app/controllers/api/v1/contacts_controller.rb
+++ b/back/app/controllers/api/v1/contacts_controller.rb
@@ -13,7 +13,7 @@ module Api
           ContactMailer.confirmation(@contact).deliver_later
           render json: { message: 'お問い合わせを受け付けました。' }, status: :created
         else
-          render json: { errors: @contact.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: @contact.errors.full_messages }, status: :unprocessable_content
         end
       end
 

--- a/back/app/controllers/api/v1/likes_controller.rb
+++ b/back/app/controllers/api/v1/likes_controller.rb
@@ -4,21 +4,21 @@ module Api
   module V1
     class LikesController < ApplicationController
       def create_post_like
-        post = Post.find(params[:id])
+        post = Post.find(params.expect(:id))
         like = post.likes.new(user: current_api_v1_user)
 
         if like.save
           post.increment!(:likes_count)
           render json: { message: 'Post liked', likes_count: post.likes_count }, status: :created
         else
-          render json: { errors: like.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: like.errors.full_messages }, status: :unprocessable_content
         end
       rescue ActiveRecord::RecordNotFound
         render json: { error: '投稿が見つかりません' }, status: :not_found
       end
 
       def destroy_post_like
-        post = Post.find(params[:id])
+        post = Post.find(params.expect(:id))
         like = post.likes.find_by(user: current_api_v1_user)
 
         if like
@@ -33,7 +33,7 @@ module Api
       end
 
       def create_comment_like
-        comment = Comment.find(params[:id])
+        comment = Comment.find(params.expect(:id))
         like = comment.likes.new(user: current_api_v1_user)
 
         if like.save
@@ -41,14 +41,14 @@ module Api
           render json: { message: 'Comment liked', likes_count: comment.likes_count },
                  status: :created
         else
-          render json: { errors: like.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: like.errors.full_messages }, status: :unprocessable_content
         end
       rescue ActiveRecord::RecordNotFound
         render json: { error: 'コメントが見つかりません' }, status: :not_found
       end
 
       def destroy_comment_like
-        comment = Comment.find(params[:id])
+        comment = Comment.find(params.expect(:id))
         like = comment.likes.find_by(user: current_api_v1_user)
 
         if like

--- a/back/app/controllers/api/v1/likes_controller.rb
+++ b/back/app/controllers/api/v1/likes_controller.rb
@@ -9,6 +9,13 @@ module Api
 
         if like.save
           post.increment!(:likes_count)
+          if post.user
+            begin
+              AchievementService.new(post.user).update_community_likes_received_achievements
+            rescue StandardError => e
+              Rails.logger.error "実績更新失敗 user_id=#{post.user.id} error=#{e.message}"
+            end
+          end
           render json: { message: 'Post liked', likes_count: post.likes_count }, status: :created
         else
           render json: { errors: like.errors.full_messages }, status: :unprocessable_content

--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -62,6 +62,11 @@ module Api
         assign_categories(@post)
 
         if @post.save
+          begin
+            AchievementService.new(current_api_v1_user).update_community_post_achievements
+          rescue StandardError => e
+            Rails.logger.error "実績更新失敗 user_id=#{current_api_v1_user.id} error=#{e.message}"
+          end
           render json: post_json(@post), status: :created
         else
           render json: { errors: @post.errors.full_messages }, status: :unprocessable_content

--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -3,7 +3,6 @@
 module Api
   module V1
     class PostsController < ApplicationController
-      before_action :authenticate_user!, except: %i[index show increment_views]
       before_action :set_post_with_associations, only: %i[show update]
       before_action :set_post, only: %i[destroy increment_views]
 
@@ -44,7 +43,15 @@ module Api
       end
 
       def show
-        render json: post_json(@post)
+        viewer = optional_current_user
+        liked_ids = if viewer
+                      Like.where(likeable_type: 'Post', likeable_id: @post.id,
+                                 user: viewer).pluck(:likeable_id).to_set
+                    else
+                      [].to_set
+                    end
+        bookmarked_ids = viewer ? Bookmark.where(post_id: @post.id, user: viewer).pluck(:post_id).to_set : [].to_set
+        render json: post_json(@post, liked_ids: liked_ids, bookmarked_ids: bookmarked_ids)
       end
 
       def create

--- a/back/app/controllers/api/v1/savings_goals_controller.rb
+++ b/back/app/controllers/api/v1/savings_goals_controller.rb
@@ -15,7 +15,7 @@ module Api
         if @savings_goal.save
           render json: @savings_goal, status: :created
         else
-          render json: { errors: @savings_goal.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: @savings_goal.errors.full_messages }, status: :unprocessable_content
         end
       end
 
@@ -23,7 +23,7 @@ module Api
         if @savings_goal.update(savings_goal_params)
           render json: @savings_goal
         else
-          render json: { errors: @savings_goal.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: @savings_goal.errors.full_messages }, status: :unprocessable_content
         end
       end
 
@@ -35,7 +35,7 @@ module Api
       private
 
       def set_savings_goal
-        @savings_goal = @current_user.savings_goals.find(params[:id])
+        @savings_goal = @current_user.savings_goals.find(params.expect(:id))
       rescue ActiveRecord::RecordNotFound
         render json: { error: '貯金目標が見つかりません' }, status: :not_found
       end

--- a/back/app/controllers/api/v1/transactions_controller.rb
+++ b/back/app/controllers/api/v1/transactions_controller.rb
@@ -38,7 +38,7 @@ module Api
           update_achievements_for_transaction(@transaction)
           render json: @transaction, status: :created
         else
-          render json: { errors: @transaction.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: @transaction.errors.full_messages }, status: :unprocessable_content
         end
       end
 
@@ -47,7 +47,7 @@ module Api
           update_achievements_for_transaction(@transaction)
           render json: @transaction
         else
-          render json: { errors: @transaction.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: @transaction.errors.full_messages }, status: :unprocessable_content
         end
       end
 
@@ -61,7 +61,7 @@ module Api
       private
 
       def set_transaction
-        @transaction = current_api_v1_user.transactions.find(params[:id])
+        @transaction = current_api_v1_user.transactions.find(params.expect(:id))
       rescue ActiveRecord::RecordNotFound
         render json: { error: '取引が見つかりません' }, status: :not_found
       end

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -50,21 +50,21 @@ class ApplicationController < ActionController::API
           Rails.logger.info "Current user set: #{Rails.env.development? ? @current_user.id : '[MASKED]'}"
         else
           Rails.logger.error 'Invalid token payload' if Rails.env.development?
-          render json: { error: 'Invalid token payload' }, status: :unauthorized
+          render json: { error: 'トークンのペイロードが無効です' }, status: :unauthorized
         end
       else
         Rails.logger.error 'Authorization token not provided' if Rails.env.development?
-        render json: { error: 'Authorization token not provided' }, status: :unauthorized
+        render json: { error: '認証トークンが指定されていません' }, status: :unauthorized
       end
     rescue ActiveRecord::RecordNotFound => e
       Rails.logger.error "User not found: #{Rails.env.development? ? e.message : '[MASKED]'}"
-      render json: { error: "User not found: #{e.message}" }, status: :unauthorized
+      render json: { error: 'ユーザーが見つかりません' }, status: :unauthorized
     rescue JWT::ExpiredSignature => e
       Rails.logger.error "Token has expired: #{Rails.env.development? ? e.message : '[MASKED]'}"
-      render json: { error: "Token has expired: #{e.message}" }, status: :unauthorized
+      render json: { error: 'トークンの有効期限が切れています' }, status: :unauthorized
     rescue JWT::DecodeError => e
       Rails.logger.error "Invalid token: #{Rails.env.development? ? e.message : '[MASKED]'}"
-      render json: { error: "Invalid token: #{e.message}" }, status: :unauthorized
+      render json: { error: '無効なトークンです' }, status: :unauthorized
     end
   end
 

--- a/back/app/controllers/concerns/exception_handler.rb
+++ b/back/app/controllers/concerns/exception_handler.rb
@@ -11,7 +11,7 @@ module ExceptionHandler
     end
 
     rescue_from ActiveRecord::RecordInvalid do |e|
-      render json: { error: e.message }, status: :unprocessable_entity
+      render json: { error: e.message }, status: :unprocessable_content
     end
 
     rescue_from ExceptionHandler::InvalidToken do |e|

--- a/back/app/services/achievement_service.rb
+++ b/back/app/services/achievement_service.rb
@@ -69,6 +69,42 @@ class AchievementService
         image_url: '/achievements/savings_30000.png',
         reward: 'ゴールドカワウソ'
       },
+      {
+        original_achievement_id: 'savings_milestone_50000',
+        title: '半歩先の安心',
+        description: '50,000円の貯金を達成しました',
+        category: :savings,
+        tier: :gold,
+        progress_target: 50_000,
+        progress: 0,
+        unlocked: false,
+        image_url: '/achievements/savings_50000.png',
+        reward: 'ゴールドバッジ'
+      },
+      {
+        original_achievement_id: 'savings_milestone_100000',
+        title: '10万円の壁を突破',
+        description: '100,000円の貯金を達成しました',
+        category: :savings,
+        tier: :gold,
+        progress_target: 100_000,
+        progress: 0,
+        unlocked: false,
+        image_url: '/achievements/savings_100000.png',
+        reward: 'プレミアムカワウソ'
+      },
+      {
+        original_achievement_id: 'savings_milestone_300000',
+        title: '貯金の達人',
+        description: '300,000円の貯金を達成しました',
+        category: :savings,
+        tier: :platinum,
+        progress_target: 300_000,
+        progress: 0,
+        unlocked: false,
+        image_url: '/achievements/savings_300000.png',
+        reward: 'プラチナカワウソ'
+      },
 
       # 連続記録関連実績
       {
@@ -182,6 +218,44 @@ class AchievementService
         unlocked: false,
         image_url: '/achievements/investment_debut.png',
         reward: '投資家バッジ'
+      },
+
+      # コミュニティ実績
+      {
+        original_achievement_id: 'community_first_post',
+        title: '初めての投稿',
+        description: '掲示板に初めて投稿しました',
+        category: :special,
+        tier: :bronze,
+        progress_target: 1,
+        progress: 0,
+        unlocked: false,
+        image_url: '/achievements/community_first_post.png',
+        reward: '投稿者バッジ'
+      },
+      {
+        original_achievement_id: 'community_likes_10',
+        title: 'みんなに愛される投稿',
+        description: '投稿への累計いいねが10件に達しました',
+        category: :special,
+        tier: :bronze,
+        progress_target: 10,
+        progress: 0,
+        unlocked: false,
+        image_url: '/achievements/community_likes_10.png',
+        reward: 'いいねバッジ'
+      },
+      {
+        original_achievement_id: 'community_likes_50',
+        title: '人気投稿者',
+        description: '投稿への累計いいねが50件に達しました',
+        category: :special,
+        tier: :silver,
+        progress_target: 50,
+        progress: 0,
+        unlocked: false,
+        image_url: '/achievements/community_likes_50.png',
+        reward: 'シルバーいいねバッジ'
       }
     ]
 
@@ -209,7 +283,7 @@ class AchievementService
       when 'savings_milestone_10000'
         total_savings = @user.total_savings || 0
         achievement.update_progress(total_savings) if total_savings >= achievement.progress_target
-      when 'savings_milestone_30000'
+      when 'savings_milestone_30000', 'savings_milestone_50000', 'savings_milestone_100000', 'savings_milestone_300000'
         total_savings = @user.total_savings || 0
         achievement.update_progress(total_savings) if total_savings >= achievement.progress_target
       end
@@ -244,6 +318,9 @@ class AchievementService
         savings_milestone_5000
         savings_milestone_10000
         savings_milestone_30000
+        savings_milestone_50000
+        savings_milestone_100000
+        savings_milestone_300000
       ]
     )
 
@@ -255,7 +332,7 @@ class AchievementService
           unlocked_at: Time.current
         )
         # 実績解除時の通知などを追加する場合はここに記述
-        Rails.logger.info "Achievement unlocked: #{achievement.title} for user #{@user.id}"
+        Rails.logger.info "実績解除: #{achievement.title} ユーザーID=#{@user.id}"
       elsif achievement.progress != total_savings
         # 進捗のみ更新（未達成の場合）
         achievement.update!(progress: total_savings)
@@ -293,6 +370,38 @@ class AchievementService
     when :investment_debut
       investment_achievement = special_achievements.find_by(original_achievement_id: 'investment_debut')
       investment_achievement&.update_progress(1)
+    end
+  end
+
+  # コミュニティ投稿実績を更新（初投稿）
+  def update_community_post_achievements
+    achievement = @user.achievements.find_by(
+      original_achievement_id: 'community_first_post',
+      unlocked: false
+    )
+    achievement&.update_progress(1)
+  end
+
+  # コミュニティいいね受信実績を更新
+  def update_community_likes_received_achievements
+    total_likes = @user.posts.sum(:likes_count)
+
+    achievements = @user.achievements.where(
+      original_achievement_id: %w[community_likes_10 community_likes_50],
+      unlocked: false
+    )
+
+    achievements.each do |achievement|
+      if total_likes >= achievement.progress_target
+        achievement.update!(
+          progress: achievement.progress_target,
+          unlocked: true,
+          unlocked_at: Time.current
+        )
+        Rails.logger.info "実績解除: #{achievement.title} ユーザーID=#{@user.id}"
+      elsif achievement.progress != total_likes
+        achievement.update!(progress: total_likes)
+      end
     end
   end
 end

--- a/back/db/migrate/20260320000000_add_unique_index_to_oauth_providers.rb
+++ b/back/db/migrate/20260320000000_add_unique_index_to_oauth_providers.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 class AddUniqueIndexToOauthProviders < ActiveRecord::Migration[7.1]
   def change
-    add_index :oauth_providers, [:provider, :uid], unique: true
+    add_index :oauth_providers, %i[provider uid], unique: true
   end
 end

--- a/back/spec/requests/api/v1/achievements_spec.rb
+++ b/back/spec/requests/api/v1/achievements_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Api::V1::Achievements', type: :request do
       expect(response).to have_http_status(:ok)
       json = response.parsed_body
       expect(json['achievements']).to be_an(Array)
-      expect(json['achievements'].map { |a| a['id'] }).to match_array([unlocked_achievement.id, locked_achievement.id])
+      expect(json['achievements'].pluck('id')).to match_array([unlocked_achievement.id, locked_achievement.id])
       expect(json['summary']).to include('total_achievements', 'unlocked_achievements')
       expect(json['summary']['total_achievements']).to eq(json['achievements'].length)
     end

--- a/back/spec/requests/api/v1/likes_spec.rb
+++ b/back/spec/requests/api/v1/likes_spec.rb
@@ -32,6 +32,27 @@ RSpec.describe 'Api::V1::Likes', type: :request do
         post "/api/v1/posts/#{post_record.id}/like", headers: headers
         expect(response).to have_http_status(:unprocessable_entity)
       end
+
+      it '合計いいねが10件に達すると投稿者のcommunity_likes_10実績が解除される' do
+        post_record.update!(likes_count: 9)
+        post_author = post_record.user
+
+        post "/api/v1/posts/#{post_record.id}/like", headers: headers
+
+        achievement = post_author.achievements.find_by(original_achievement_id: 'community_likes_10')
+        expect(achievement.reload.unlocked).to be true
+      end
+
+      it '合計いいねが10未満の場合は進捗のみ更新される' do
+        post_record.update!(likes_count: 5)
+        post_author = post_record.user
+
+        post "/api/v1/posts/#{post_record.id}/like", headers: headers
+
+        achievement = post_author.achievements.find_by(original_achievement_id: 'community_likes_10')
+        expect(achievement.reload.unlocked).to be false
+        expect(achievement.reload.progress).to eq(6)
+      end
     end
 
     describe 'POST /api/v1/posts/:post_id/unlike' do

--- a/back/spec/requests/api/v1/posts_spec.rb
+++ b/back/spec/requests/api/v1/posts_spec.rb
@@ -57,6 +57,27 @@ RSpec.describe 'Api::V1::Posts', type: :request do
       get '/api/v1/posts/0'
       expect(response).to have_http_status(:not_found)
     end
+
+    it '認証済みユーザーはliked_by_meが正しく返る' do
+      create(:like, user: user, likeable: post_record)
+      get "/api/v1/posts/#{post_record.id}", headers: headers
+      json = response.parsed_body
+      expect(json['liked_by_me']).to be true
+    end
+
+    it '認証済みユーザーはbookmarked_by_meが正しく返る' do
+      create(:bookmark, user: user, post: post_record)
+      get "/api/v1/posts/#{post_record.id}", headers: headers
+      json = response.parsed_body
+      expect(json['bookmarked_by_me']).to be true
+    end
+
+    it '未認証ユーザーはliked_by_meとbookmarked_by_meがfalseになる' do
+      get "/api/v1/posts/#{post_record.id}"
+      json = response.parsed_body
+      expect(json['liked_by_me']).to be false
+      expect(json['bookmarked_by_me']).to be false
+    end
   end
 
   describe 'POST /api/v1/posts' do

--- a/back/spec/requests/api/v1/posts_spec.rb
+++ b/back/spec/requests/api/v1/posts_spec.rb
@@ -98,6 +98,13 @@ RSpec.describe 'Api::V1::Posts', type: :request do
       expect(json['categories']).to include('節約', '家計簿')
     end
 
+    it '投稿作成時にcommunity_first_post実績が解除される' do
+      post '/api/v1/posts', params: valid_params, headers: headers
+      expect(response).to have_http_status(:created)
+      achievement = user.achievements.find_by(original_achievement_id: 'community_first_post')
+      expect(achievement.reload.unlocked).to be true
+    end
+
     it '未認証では投稿できない' do
       post '/api/v1/posts', params: valid_params
       expect(response).to have_http_status(:unauthorized)


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要

Issue #204 の対応。貯金マイルストーン上限を拡充し、掲示板活動に連動したコミュニティ実績を追加する。

## 詳細な変更点

### バックエンド

- [x] `savings_milestone_50000`（gold: 50,000円）を追加
- [x] `savings_milestone_100000`（gold: 100,000円）を追加
- [x] `savings_milestone_300000`（platinum: 300,000円）を追加
- [x] `community_first_post`（bronze/special: 初投稿）を追加
- [x] `community_likes_10`（bronze/special: 累計いいね10件受信）を追加
- [x] `community_likes_50`（silver/special: 累計いいね50件受信）を追加
- [x] `AchievementService#create_initial_achievements` に6件追加
- [x] `update_milestone_achievements` の判定IDリストに新マイルストーン3件を追加
- [x] `update_savings_achievements` の `case` ブランチに新マイルストーン3件を追加
- [x] `update_community_post_achievements` メソッドを追加
- [x] `update_community_likes_received_achievements` メソッドを追加
- [x] `PostsController#create` で `update_community_post_achievements` を呼ぶ
- [x] `LikesController#create_post_like` で投稿者の `update_community_likes_received_achievements` を呼ぶ
- [x] 実績更新失敗が投稿・いいね処理に影響しないよう `rescue StandardError` で例外隔離
- [x] `post.user` が nil の場合のガード処理を追加
- [x] `Metrics/ClassLength` のサービス除外を `.rubocop.yml` に追加

### テスト追加

- [x] 投稿作成時に `community_first_post` 実績が解除されることを確認
- [x] 累計いいね10件で `community_likes_10` 実績が解除されることを確認
- [x] 累計いいね10未満の場合は進捗のみ更新されることを確認

### フロントエンド

- 新規実績はコレクションページで `special` カテゴリとして既存UIで表示される（追加対応不要）

## 修正された問題

fix #204

<!-- I want to review in Japanese. -->