### PR TITLE
feat: ストリーク・予算管理・特別実績の自動トリガーを実装する

### DIFF
--- a/back/app/controllers/api/v1/budgets_controller.rb
+++ b/back/app/controllers/api/v1/budgets_controller.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class BudgetsController < ApplicationController
+      before_action :set_budget, only: %i[update]
+
+      def index
+        @budgets = current_api_v1_user.budgets.order(year: :desc, month: :desc)
+        render json: @budgets
+      end
+
+      def current
+        today = Date.current
+        budget = current_api_v1_user.budgets.find_by(year: today.year, month: today.month)
+        total_expense = current_api_v1_user.transactions
+                                           .where(transaction_type: 'expense')
+                                           .where(date: today.all_month)
+                                           .sum(:amount)
+
+        render json: {
+          budget: budget,
+          total_expense: total_expense,
+          within_budget: budget ? total_expense <= budget.amount : nil,
+          remaining: budget ? budget.amount - total_expense : nil
+        }
+      end
+
+      def create
+        @budget = current_api_v1_user.budgets.new(budget_params)
+        if @budget.save
+          trigger_budget_first_set_achievement
+          render json: @budget, status: :created
+        else
+          render json: { errors: @budget.errors.full_messages }, status: :unprocessable_content
+        end
+      end
+
+      def update
+        if @budget.update(budget_params)
+          render json: @budget
+        else
+          render json: { errors: @budget.errors.full_messages }, status: :unprocessable_content
+        end
+      end
+
+      private
+
+      def set_budget
+        @budget = current_api_v1_user.budgets.find(params.expect(:id))
+      rescue ActiveRecord::RecordNotFound
+        render json: { error: '予算が見つかりません' }, status: :not_found
+      end
+
+      def budget_params
+        params.expect(budget: %i[year month amount])
+      end
+
+      def trigger_budget_first_set_achievement
+        service = AchievementService.new(current_api_v1_user)
+        service.update_expense_achievements({ budget_set: true, within_budget: false, consecutive_months: 0 })
+      rescue StandardError => e
+        Rails.logger.error "実績更新エラー（予算設定）: #{e.message}"
+      end
+    end
+  end
+end

--- a/back/app/controllers/api/v1/savings_goals_controller.rb
+++ b/back/app/controllers/api/v1/savings_goals_controller.rb
@@ -5,14 +5,17 @@ module Api
     class SavingsGoalsController < ApplicationController
       before_action :set_savings_goal, only: %i[update destroy]
 
+      EMERGENCY_FUND_THRESHOLD = 100_000
+
       def index
-        @savings_goals = @current_user.savings_goals.order(created_at: :desc)
+        @savings_goals = current_api_v1_user.savings_goals.order(created_at: :desc)
         render json: @savings_goals
       end
 
       def create
-        @savings_goal = @current_user.savings_goals.new(savings_goal_params)
+        @savings_goal = current_api_v1_user.savings_goals.new(savings_goal_params)
         if @savings_goal.save
+          trigger_emergency_fund_achievement(@savings_goal)
           render json: @savings_goal, status: :created
         else
           render json: { errors: @savings_goal.errors.full_messages }, status: :unprocessable_content
@@ -20,7 +23,9 @@ module Api
       end
 
       def update
+        was_achieved = goal_achieved?(@savings_goal)
         if @savings_goal.update(savings_goal_params)
+          trigger_goal_first_achieved(@savings_goal, was_achieved)
           render json: @savings_goal
         else
           render json: { errors: @savings_goal.errors.full_messages }, status: :unprocessable_content
@@ -35,13 +40,38 @@ module Api
       private
 
       def set_savings_goal
-        @savings_goal = @current_user.savings_goals.find(params.expect(:id))
+        @savings_goal = current_api_v1_user.savings_goals.find(params.expect(:id))
       rescue ActiveRecord::RecordNotFound
         render json: { error: '貯金目標が見つかりません' }, status: :not_found
       end
 
       def savings_goal_params
         params.expect(savings_goal: %i[title target_amount current_amount deadline])
+      end
+
+      def goal_achieved?(goal)
+        goal.current_amount.present? && goal.current_amount >= goal.target_amount
+      end
+
+      # 更新後に初めて達成した場合のみ goal_first_achieved を解除する
+      def trigger_goal_first_achieved(goal, was_achieved_before)
+        return if was_achieved_before
+        return unless goal_achieved?(goal)
+
+        service = AchievementService.new(current_api_v1_user)
+        service.update_special_achievements(:goal_achieved)
+      rescue StandardError => e
+        Rails.logger.error "実績更新エラー（目標達成）: #{e.message}"
+      end
+
+      # 緊急資金規模（10万円以上）の貯金目標作成時に解除する
+      def trigger_emergency_fund_achievement(goal)
+        return unless goal.target_amount >= EMERGENCY_FUND_THRESHOLD
+
+        service = AchievementService.new(current_api_v1_user)
+        service.update_special_achievements(:emergency_fund)
+      rescue StandardError => e
+        Rails.logger.error "実績更新エラー（緊急資金）: #{e.message}"
       end
     end
   end

--- a/back/app/controllers/api/v1/transactions_controller.rb
+++ b/back/app/controllers/api/v1/transactions_controller.rb
@@ -70,14 +70,23 @@ module Api
         params.expect(transaction: %i[amount transaction_type category description date])
       end
 
-      # 収入取引の登録・更新後に実績を更新する
+      # 取引の登録・更新後に実績を更新する
       def update_achievements_for_transaction(transaction)
-        return unless transaction.income?
-
         service = AchievementService.new(current_api_v1_user)
-        service.update_savings_achievements(transaction.amount)
-        service.update_milestone_achievements
+
+        if transaction.income?
+          service.update_savings_achievements(transaction.amount)
+          service.update_milestone_achievements
+          # 投資カテゴリの取引で investment_debut 実績を解除する
+          service.update_special_achievements(:investment_debut) if transaction.category == 'investment'
+        end
+
+        # income/expense どちらの取引でもストリークを再計算する
+        # （expense を先に登録した日に income が後から来たとき最新状態を反映させるため）
         service.update_streak_achievements(current_api_v1_user.current_streak)
+
+        # expense 取引のとき予算実績をチェックする
+        update_budget_achievements(service) if transaction.expense?
       rescue StandardError => e
         Rails.logger.error "実績更新エラー: #{e.message}"
       end
@@ -88,6 +97,28 @@ module Api
         service.update_milestone_achievements
       rescue StandardError => e
         Rails.logger.error "実績更新エラー（削除後）: #{e.message}"
+      end
+
+      # 予算実績（budget_keeper_month / budget_master_3months）をチェックして更新する
+      def update_budget_achievements(service)
+        budget_status = build_budget_status(service)
+        return unless budget_status
+
+        service.update_expense_achievements(budget_status)
+      end
+
+      def build_budget_status(service)
+        today = Date.current
+        budget = current_api_v1_user.budgets.find_by(year: today.year, month: today.month)
+        return nil unless budget
+
+        within = service.within_current_month_budget?(budget.amount)
+        budgets_by_month = current_api_v1_user.budgets.to_h do |b|
+          [[b.year, b.month], b.amount]
+        end
+        consecutive = service.calculate_consecutive_budget_months(budgets_by_month)
+
+        { budget_set: true, within_budget: within, consecutive_months: consecutive }
       end
     end
   end

--- a/back/app/models/budget.rb
+++ b/back/app/models/budget.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Budget < ApplicationRecord
+  belongs_to :user
+
+  validates :year,   presence: true, numericality: { only_integer: true, greater_than: 2000 }
+  validates :month,  presence: true, numericality: { only_integer: true, in: 1..12 }
+  validates :amount, presence: true, numericality: { greater_than: 0 }
+  validates :year, uniqueness: { scope: %i[user_id month], message: 'その月の予算はすでに登録されています' }
+end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :bookmarks, dependent: :destroy
   has_many :user_actions, dependent: :destroy
+  has_many :budgets, dependent: :destroy
 
   # 貯金関連のアソシエーション（transactions の中から income タイプを取得）
   has_many :savings, -> { where(transaction_type: 'income') }, class_name: 'Transaction'
@@ -171,59 +172,58 @@ class User < ApplicationRecord
   end
 
   def current_streak
-    return 0 if transactions.where(transaction_type: 'income').empty?
+    dates = income_transaction_dates
+    return 0 if dates.empty?
 
     today = Date.current
+    # 今日に記録があればそこから、なければ昨日から遡る
+    start_date = dates.include?(today) ? today : today - 1.day
+    return 0 unless dates.include?(start_date)
+
     streak = 0
-    current_date = today
-
-    # 今日の記録があるか確認
-    has_today_record = transactions.where(transaction_type: 'income').exists?(created_at: today.all_day)
-
-    # 昨日までの記録を確認
-    loop do
-      has_record = transactions.where(transaction_type: 'income').exists?(created_at: current_date.all_day)
-
-      break unless has_record
-
+    check_date = start_date
+    while dates.include?(check_date)
       streak += 1
-      current_date -= 1.day
+      check_date -= 1.day
     end
-
-    # 今日の記録がある場合は1を加算
-    streak += 1 if has_today_record
-
     streak
   end
 
   def longest_streak
-    return 0 if transactions.where(transaction_type: 'income').empty?
-
-    dates = transactions.where(transaction_type: 'income').pluck(:created_at).map(&:to_date).uniq.sort
+    dates = income_transaction_dates
     return 0 if dates.empty?
+    return 1 if dates.size == 1
 
-    current_streak = 1
-    longest_streak = 1
-    previous_date = dates.first
-
-    dates[1..].each do |date|
-      if date == previous_date + 1.day
-        current_streak += 1
-        longest_streak = [longest_streak, current_streak].max
+    current = 1
+    longest = 1
+    dates[1..].each_with_index do |date, i|
+      if date == dates[i] + 1.day
+        current += 1
+        longest = [longest, current].max
       else
-        current_streak = 1
+        current = 1
       end
-      previous_date = date
     end
-
-    longest_streak
+    longest
   end
 
   def streak_status
     {
       current_streak: current_streak,
       longest_streak: longest_streak,
-      last_record_date: transactions.where(transaction_type: 'income').last&.created_at&.to_date
+      last_record_date: transactions.where(transaction_type: 'income').maximum(:date)&.to_date
     }
+  end
+
+  private
+
+  def income_transaction_dates
+    transactions
+      .where(transaction_type: 'income')
+      .pluck(:date)
+      .compact
+      .map(&:to_date)
+      .uniq
+      .sort
   end
 end

--- a/back/app/services/achievement_service.rb
+++ b/back/app/services/achievement_service.rb
@@ -351,7 +351,8 @@ class AchievementService
       when 'budget_keeper_month'
         achievement.update_progress(1) if budget_status[:within_budget]
       when 'budget_master_3months'
-        achievement.update_progress(budget_status[:consecutive_months]) if budget_status[:consecutive_months] >= 3
+        # 中間進捗（1・2ヶ月）も反映させるため条件なしで更新する
+        achievement.update_progress(budget_status[:consecutive_months])
       end
     end
   end
@@ -371,6 +372,39 @@ class AchievementService
       investment_achievement = special_achievements.find_by(original_achievement_id: 'investment_debut')
       investment_achievement&.update_progress(1)
     end
+  end
+
+  # 今月の支出が予算内かどうか確認する
+  def within_current_month_budget?(monthly_limit)
+    today = Date.current
+    expense = @user.transactions
+                   .where(transaction_type: 'expense')
+                   .where(date: today.all_month)
+                   .sum(:amount)
+    expense <= monthly_limit
+  end
+
+  # 月初から遡って連続で予算内に収まっている月数を計算する
+  def calculate_consecutive_budget_months(budgets_by_month)
+    months = 0
+    check_date = Date.current.beginning_of_month
+
+    3.times do
+      key = [check_date.year, check_date.month]
+      monthly_limit = budgets_by_month[key]
+      break unless monthly_limit
+
+      expense = @user.transactions
+                     .where(transaction_type: 'expense')
+                     .where(date: check_date.all_month)
+                     .sum(:amount)
+      break if expense > monthly_limit
+
+      months += 1
+      check_date = check_date.prev_month.beginning_of_month
+    end
+
+    months
   end
 
   # コミュニティ投稿実績を更新（初投稿）

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -20,6 +20,11 @@ Rails.application.routes.draw do
       resources :transactions, only: %i[index create update destroy] # 取引関連
       resources :savings_goals, only: %i[index create update destroy] # 貯金目標関連
       resources :achievements, only: %i[index show update] # 実績関連
+      resources :budgets, only: %i[index create update] do # 予算関連（削除不可・update で上書き運用）
+        collection do
+          get :current
+        end
+      end
 
       # 掲示板管理
       resources :posts do

--- a/back/db/migrate/20260606051105_create_budgets.rb
+++ b/back/db/migrate/20260606051105_create_budgets.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateBudgets < ActiveRecord::Migration[8.1]
+  def change
+    create_table :budgets do |t|
+      t.references :user, null: false, foreign_key: true
+      t.integer :year,   null: false
+      t.integer :month,  null: false
+      t.decimal :amount, null: false
+
+      t.timestamps
+    end
+
+    add_index :budgets, %i[user_id year month], unique: true
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_05_141950) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_06_051105) do
   create_table "achievements", force: :cascade do |t|
     t.integer "category", default: 0, null: false
     t.datetime "created_at", null: false
@@ -42,6 +42,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_05_141950) do
     t.index ["post_id"], name: "index_bookmarks_on_post_id"
     t.index ["user_id", "post_id"], name: "index_bookmarks_on_user_and_post", unique: true
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
+  end
+
+  create_table "budgets", force: :cascade do |t|
+    t.decimal "amount", null: false
+    t.datetime "created_at", null: false
+    t.integer "month", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.integer "year", null: false
+    t.index ["user_id", "year", "month"], name: "index_budgets_on_user_id_and_year_and_month", unique: true
+    t.index ["user_id"], name: "index_budgets_on_user_id"
   end
 
   create_table "categories", force: :cascade do |t|
@@ -183,6 +194,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_05_141950) do
   add_foreign_key "achievements", "users"
   add_foreign_key "bookmarks", "posts"
   add_foreign_key "bookmarks", "users"
+  add_foreign_key "budgets", "users"
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"
   add_foreign_key "likes", "users"

--- a/back/spec/factories/budgets.rb
+++ b/back/spec/factories/budgets.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :budget do
+    association :user
+    year  { Date.current.year }
+    month { Date.current.month }
+    amount { 50_000 }
+  end
+end

--- a/back/spec/models/budget_spec.rb
+++ b/back/spec/models/budget_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Budget, type: :model do
+  it { should belong_to(:user) }
+  it { should validate_presence_of(:year) }
+  it { should validate_presence_of(:month) }
+  it { should validate_presence_of(:amount) }
+
+  describe 'バリデーション' do
+    let(:user) { create(:user) }
+
+    it '有効な予算を作成できる' do
+      budget = build(:budget, user: user)
+      expect(budget).to be_valid
+    end
+
+    it 'amount が 0 以下の場合は無効' do
+      budget = build(:budget, user: user, amount: 0)
+      expect(budget).not_to be_valid
+    end
+
+    it 'month が 0 の場合は無効' do
+      budget = build(:budget, user: user, month: 0)
+      expect(budget).not_to be_valid
+    end
+
+    it 'month が 13 の場合は無効' do
+      budget = build(:budget, user: user, month: 13)
+      expect(budget).not_to be_valid
+    end
+
+    it '同一ユーザー・同一月の予算は重複登録できない' do
+      create(:budget, user: user, year: 2026, month: 6)
+      duplicate = build(:budget, user: user, year: 2026, month: 6)
+      expect(duplicate).not_to be_valid
+    end
+
+    it '別ユーザーの同一月は登録できる' do
+      other_user = create(:user)
+      create(:budget, user: user, year: 2026, month: 6)
+      budget = build(:budget, user: other_user, year: 2026, month: 6)
+      expect(budget).to be_valid
+    end
+  end
+end

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -85,6 +85,76 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#current_streak' do
+    let(:user) { create(:user) }
+
+    it '取引が0件のとき0を返す' do
+      expect(user.current_streak).to eq(0)
+    end
+
+    it '今日だけ収入取引があるとき1を返す' do
+      create(:transaction, user: user, transaction_type: :income, date: Date.current)
+      expect(user.current_streak).to eq(1)
+    end
+
+    it '今日と昨日に収入取引があるとき2を返す' do
+      create(:transaction, user: user, transaction_type: :income, date: Date.current)
+      create(:transaction, user: user, transaction_type: :income, date: Date.current - 1.day)
+      expect(user.current_streak).to eq(2)
+    end
+
+    it '今日の記録がなく昨日まで連続している場合は昨日から遡った日数を返す' do
+      create(:transaction, user: user, transaction_type: :income, date: Date.current - 1.day)
+      create(:transaction, user: user, transaction_type: :income, date: Date.current - 2.days)
+      expect(user.current_streak).to eq(2)
+    end
+
+    it '今日も昨日も記録がなければ0を返す' do
+      create(:transaction, user: user, transaction_type: :income, date: Date.current - 3.days)
+      expect(user.current_streak).to eq(0)
+    end
+
+    it 'created_at ではなく date カラムを参照する' do
+      # date は2日前だが created_at は今日の取引を作成
+      create(:transaction, user: user, transaction_type: :income, date: Date.current - 2.days)
+      expect(user.current_streak).to eq(0)
+    end
+
+    it '二重カウントしない（今日の取引1件のとき1を返す）' do
+      create(:transaction, user: user, transaction_type: :income, date: Date.current)
+      expect(user.current_streak).to eq(1)
+    end
+
+    it '収入取引のみカウントし、支出取引は無視する' do
+      create(:transaction, user: user, transaction_type: :expense, date: Date.current)
+      expect(user.current_streak).to eq(0)
+    end
+  end
+
+  describe '#longest_streak' do
+    let(:user) { create(:user) }
+
+    it '取引が0件のとき0を返す' do
+      expect(user.longest_streak).to eq(0)
+    end
+
+    it '連続していない複数の期間があるとき最長を返す' do
+      # 3日連続 + 1日空白 + 2日連続
+      create(:transaction, user: user, transaction_type: :income, date: Date.current - 6.days)
+      create(:transaction, user: user, transaction_type: :income, date: Date.current - 5.days)
+      create(:transaction, user: user, transaction_type: :income, date: Date.current - 4.days)
+      create(:transaction, user: user, transaction_type: :income, date: Date.current - 2.days)
+      create(:transaction, user: user, transaction_type: :income, date: Date.current - 1.day)
+      expect(user.longest_streak).to eq(3)
+    end
+
+    it 'date カラムを参照する' do
+      create(:transaction, user: user, transaction_type: :income, date: Date.current - 1.day)
+      create(:transaction, user: user, transaction_type: :income, date: Date.current)
+      expect(user.longest_streak).to eq(2)
+    end
+  end
+
   describe '#oauth_only?' do
     it 'OAuthプロバイダーのみで登録したユーザーはtrueを返す' do
       user = create(:user)

--- a/back/spec/requests/api/v1/budgets_spec.rb
+++ b/back/spec/requests/api/v1/budgets_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Budgets', type: :request do
+  let(:user)    { create(:user) }
+  let(:token)   { JsonWebToken.encode(user_id: user.id) }
+  let(:headers) { { 'Authorization' => "Bearer #{token}" } }
+
+  describe 'GET /api/v1/budgets' do
+    before { create(:budget, user: user) }
+
+    it '認証済みで予算一覧を返す' do
+      get '/api/v1/budgets', headers: headers
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to be_an(Array)
+    end
+
+    it '未認証では 401 を返す' do
+      get '/api/v1/budgets'
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe 'GET /api/v1/budgets/current' do
+    context '今月の予算が存在する場合' do
+      before do
+        create(:budget, user: user, year: Date.current.year, month: Date.current.month, amount: 50_000)
+        create(:transaction, user: user, transaction_type: :expense, amount: 20_000, date: Date.current)
+      end
+
+      it 'budget・total_expense・within_budget・remaining を返す' do
+        get '/api/v1/budgets/current', headers: headers
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json['budget']).to be_present
+        expect(json['total_expense']).to eq('20000.0')
+        expect(json['within_budget']).to be true
+        expect(json['remaining']).to eq('30000.0')
+      end
+    end
+
+    context '今月の予算が存在しない場合' do
+      it 'budget が null を返す' do
+        get '/api/v1/budgets/current', headers: headers
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json['budget']).to be_nil
+      end
+    end
+
+    it '未認証では 401 を返す' do
+      get '/api/v1/budgets/current'
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe 'POST /api/v1/budgets' do
+    let(:valid_params) { { budget: { year: Date.current.year, month: Date.current.month, amount: 50_000 } } }
+
+    it '有効なパラメータで予算を作成できる' do
+      post '/api/v1/budgets', params: valid_params, headers: headers
+      expect(response).to have_http_status(:created)
+    end
+
+    it '予算作成後に budget_first_set 実績が解除される' do
+      achievement = user.achievements.find_by(original_achievement_id: 'budget_first_set')
+      expect { post '/api/v1/budgets', params: valid_params, headers: headers }
+        .to change { achievement.reload.unlocked }.from(false).to(true)
+    end
+
+    it '同一月の重複登録は 422 を返す' do
+      create(:budget, user: user, year: Date.current.year, month: Date.current.month)
+      post '/api/v1/budgets', params: valid_params, headers: headers
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    it '未認証では 401 を返す' do
+      post '/api/v1/budgets', params: valid_params
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe 'PATCH /api/v1/budgets/:id' do
+    let(:budget) { create(:budget, user: user) }
+
+    it '自分の予算を更新できる' do
+      patch "/api/v1/budgets/#{budget.id}", params: { budget: { amount: 60_000 } }, headers: headers
+      expect(response).to have_http_status(:ok)
+      expect(budget.reload.amount).to eq(60_000)
+    end
+
+    it '他ユーザーの予算には 404 を返す' do
+      other_budget = create(:budget, user: create(:user))
+      patch "/api/v1/budgets/#{other_budget.id}", params: { budget: { amount: 60_000 } }, headers: headers
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it '未認証では 401 を返す' do
+      patch "/api/v1/budgets/#{budget.id}", params: { budget: { amount: 60_000 } }
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end

--- a/back/spec/requests/api/v1/savings_goals_spec.rb
+++ b/back/spec/requests/api/v1/savings_goals_spec.rb
@@ -39,6 +39,22 @@ RSpec.describe 'Api::V1::SavingsGoals', type: :request do
       post '/api/v1/savings_goals', params: valid_params
       expect(response).to have_http_status(:unauthorized)
     end
+
+    context '緊急資金実績' do
+      it 'target_amount が 100,000 以上のとき emergency_fund_created が解除される' do
+        achievement = user.achievements.find_by(original_achievement_id: 'emergency_fund_created')
+        post '/api/v1/savings_goals', params: valid_params, headers: headers
+        expect(achievement.reload.unlocked).to be true
+      end
+
+      it 'target_amount が 99,999 のとき emergency_fund_created は解除されない' do
+        achievement = user.achievements.find_by(original_achievement_id: 'emergency_fund_created')
+        params = { savings_goal: { title: '小さな目標', target_amount: 99_999, current_amount: 0,
+                                   deadline: 1.year.from_now.to_date } }
+        post '/api/v1/savings_goals', params: params, headers: headers
+        expect(achievement.reload.unlocked).to be false
+      end
+    end
   end
 
   describe 'PATCH /api/v1/savings_goals/:id' do
@@ -51,6 +67,36 @@ RSpec.describe 'Api::V1::SavingsGoals', type: :request do
       expect(response).to have_http_status(:ok)
       expect(savings_goal.reload.title).to eq('新しいタイトル')
       expect(savings_goal.reload.current_amount.to_f).to eq(10_000.0)
+    end
+
+    context '目標達成実績' do
+      it 'current_amount >= target_amount になる更新で goal_first_achieved が解除される' do
+        achievement = user.achievements.find_by(original_achievement_id: 'goal_first_achieved')
+        patch "/api/v1/savings_goals/#{savings_goal.id}",
+              params: { savings_goal: { current_amount: 50_000 } },
+              headers: headers
+        expect(achievement.reload.unlocked).to be true
+      end
+
+      it 'すでに達成済みの目標を更新しても goal_first_achieved は再解除されない（べき等）' do
+        savings_goal.update!(current_amount: 50_000)
+        achievement = user.achievements.find_by(original_achievement_id: 'goal_first_achieved')
+        achievement.update!(unlocked: true, unlocked_at: Time.current)
+        unlocked_at = achievement.unlocked_at
+
+        patch "/api/v1/savings_goals/#{savings_goal.id}",
+              params: { savings_goal: { current_amount: 50_000 } },
+              headers: headers
+        expect(achievement.reload.unlocked_at).to be_within(1.second).of(unlocked_at)
+      end
+
+      it '未達成のまま更新しても goal_first_achieved は解除されない' do
+        achievement = user.achievements.find_by(original_achievement_id: 'goal_first_achieved')
+        patch "/api/v1/savings_goals/#{savings_goal.id}",
+              params: { savings_goal: { current_amount: 10_000 } },
+              headers: headers
+        expect(achievement.reload.unlocked).to be false
+      end
     end
 
     it '他ユーザーの貯金目標にはアクセスできない' do

--- a/back/spec/requests/api/v1/transactions_spec.rb
+++ b/back/spec/requests/api/v1/transactions_spec.rb
@@ -102,6 +102,51 @@ RSpec.describe 'Api::V1::Transactions', type: :request do
         first_savings = user.achievements.find_by(original_achievement_id: 'first_savings')
         expect(first_savings.reload.unlocked).to be false
       end
+
+      it '投資カテゴリの収入取引を作成すると investment_debut が解除される' do
+        post '/api/v1/transactions',
+             params: { transaction: { amount: 10_000, transaction_type: 'income', category: 'investment',
+                                      description: '投資', date: Date.current } },
+             headers: headers
+
+        expect(response).to have_http_status(:created)
+        achievement = user.achievements.find_by(original_achievement_id: 'investment_debut')
+        expect(achievement.reload.unlocked).to be true
+      end
+
+      it '投資以外のカテゴリの収入取引では investment_debut は解除されない' do
+        post '/api/v1/transactions',
+             params: { transaction: { amount: 10_000, transaction_type: 'income', category: 'salary',
+                                      description: '給料', date: Date.current } },
+             headers: headers
+
+        achievement = user.achievements.find_by(original_achievement_id: 'investment_debut')
+        expect(achievement.reload.unlocked).to be false
+      end
+
+      context '予算実績' do
+        let!(:budget) do
+          create(:budget, user: user, year: Date.current.year, month: Date.current.month, amount: 50_000)
+        end
+
+        it '支出が予算内のとき budget_keeper_month が解除される' do
+          achievement = user.achievements.find_by(original_achievement_id: 'budget_keeper_month')
+          post '/api/v1/transactions',
+               params: { transaction: { amount: 10_000, transaction_type: 'expense', category: '食費',
+                                        description: '食費', date: Date.current } },
+               headers: headers
+          expect(achievement.reload.unlocked).to be true
+        end
+
+        it '支出が予算を超えたとき budget_keeper_month は解除されない' do
+          achievement = user.achievements.find_by(original_achievement_id: 'budget_keeper_month')
+          post '/api/v1/transactions',
+               params: { transaction: { amount: 60_000, transaction_type: 'expense', category: '食費',
+                                        description: '食費', date: Date.current } },
+               headers: headers
+          expect(achievement.reload.unlocked).to be false
+        end
+      end
     end
   end
 

--- a/front/src/app/collection/page.tsx
+++ b/front/src/app/collection/page.tsx
@@ -1,14 +1,14 @@
 "use client"
 
 import { useRouter } from "next/navigation"
-import { useState, useEffect } from "react"
+import { useEffect, useMemo } from "react"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Progress } from "@/components/ui/progress"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import Image from "next/image"
 import { cn } from "@/lib/utils"
-import { LockIcon, UnlockIcon, AlertTriangle, Trophy } from 'lucide-react';
+import { LockIcon, UnlockIcon, AlertTriangle, Trophy, Clock, History } from 'lucide-react';
 import { useAuth } from "@/hooks/useAuth"
 import { useAchievements } from "@/hooks/useAchievements"
 
@@ -18,7 +18,18 @@ const categoryLabels: Record<string, string> = {
   savings: '貯金',
   streak: '連続記録',
   expense: '支出管理',
-  special: '特別'
+  special: '特別',
+  history: '解除履歴',
+};
+
+const formatUnlockedAt = (dateStr: string): string => {
+  return new Intl.DateTimeFormat('ja-JP', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(dateStr));
 };
 
 // ティア表示用の日本語マッピング
@@ -49,8 +60,20 @@ export default function CollectionPage() {
     }
   }, [authIsLoading, isAuthenticated, router])
 
-  // 表示するカテゴリを動的に生成
-  const achievementCategories = ["all", ...new Set(achievements.map(ach => ach.category))];
+  // 解除済み実績を unlocked_at 降順で並べた履歴リスト
+  const historyAchievements = useMemo(
+    () =>
+      [...achievements]
+        .filter((ach) => ach.unlocked && ach.unlockedAt)
+        .sort((a, b) => new Date(b.unlockedAt!).getTime() - new Date(a.unlockedAt!).getTime()),
+    [achievements]
+  );
+
+  // 表示するカテゴリを動的に生成（履歴タブを末尾に固定追加）
+  const achievementCategories = useMemo(
+    () => ["all", ...new Set(achievements.map((ach) => ach.category)), "history"],
+    [achievements]
+  );
 
   return (
     <div className="container mx-auto p-4 md:p-6 lg:p-8 bg-background text-foreground">
@@ -130,13 +153,39 @@ export default function CollectionPage() {
           </div>
         )}
 
-        {!isLoading && !error && filteredAchievements.length === 0 && (
+        {/* 解除履歴タブ */}
+        {!isLoading && !error && activeTab === "history" && (
+          historyAchievements.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-16 text-muted-foreground gap-3">
+              <History className="h-12 w-12 opacity-30" />
+              <p className="text-sm">まだ解除した実績がありません。</p>
+            </div>
+          ) : (
+            <div className="bg-card border rounded-lg divide-y divide-border">
+              {historyAchievements.map((ach) => (
+                <div key={ach.id} className="flex items-center gap-4 px-4 py-3 hover:bg-muted/50 transition-colors">
+                  <Clock className="h-4 w-4 text-muted-foreground shrink-0" />
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium text-foreground truncate">{ach.title}</p>
+                    <p className="text-xs text-muted-foreground">{formatUnlockedAt(ach.unlockedAt!)}</p>
+                  </div>
+                  <Badge variant="secondary" className="text-xs shrink-0 bg-secondary text-secondary-foreground">
+                    {tierLabels[ach.tier] ?? ach.tier}
+                  </Badge>
+                </div>
+              ))}
+            </div>
+          )
+        )}
+
+        {/* カテゴリフィルタータブ（履歴タブ以外） */}
+        {!isLoading && !error && activeTab !== "history" && filteredAchievements.length === 0 && (
           <p className="text-muted-foreground py-4">
             {activeTab === "all" ? "実績はまだありません。" : `このカテゴリ (${categoryLabels[activeTab] ?? activeTab}) の実績はまだありません。`}
           </p>
         )}
 
-        {!isLoading && !error && filteredAchievements.length > 0 && (
+        {!isLoading && !error && activeTab !== "history" && filteredAchievements.length > 0 && (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
             {filteredAchievements.map((ach) => (
               <Card

--- a/front/src/hooks/useAchievements.ts
+++ b/front/src/hooks/useAchievements.ts
@@ -57,7 +57,7 @@ export function useAchievements(): UseAchievementsReturn {
   const filterAchievements = useCallback(
     (category: string) => {
       setActiveTab(category)
-      if (category === 'all') {
+      if (category === 'all' || category === 'history') {
         setFilteredAchievements(achievements)
       } else {
         setFilteredAchievements(


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要

issue #203 で定義されたストリーク・予算管理・特別実績の自動トリガーを実装しました。既存の `AchievementService` に実装済みのロジックを、各コントローラーの適切なタイミングで呼び出す仕組みを整備しています。

## 詳細な変更点

### バグ修正
- [x] `User#current_streak` を修正（`created_at` → `date` カラム使用、二重カウントバグを除去）
- [x] `User#longest_streak` / `streak_status` も同様に `date` カラムへ統一
- [x] `AchievementService#update_expense_achievements` の `budget_master_3months` が `>= 3` のときしか更新されていなかったバグを修正（中間進捗も反映）

### 新規機能（Budget）
- [x] `budgets` テーブルのマイグレーション作成（`user_id`, `year`, `month`, `amount`、同一月の UNIQUE インデックス付き）
- [x] `Budget` モデル作成（バリデーション・アソシエーション）
- [x] `BudgetsController` 作成（`index` / `current` / `create` / `update`）
  - `GET /api/v1/budgets/current` — 今月の予算・支出合計・予算達成状況を返す
  - `POST /api/v1/budgets` — 初回作成時に `budget_first_set` 実績を解除

### 実績トリガー追加
- [x] `SavingsGoalsController`:
  - `create` 時、`target_amount >= 100,000` なら `emergency_fund_created` を解除
  - `update` 時、未達成 → 達成 の遷移で `goal_first_achieved` を解除（べき等）
- [x] `TransactionsController`:
  - `income` + `category == 'investment'` のとき `investment_debut` を解除
  - `expense` 取引時に予算実績（`budget_keeper_month` / `budget_master_3months`）をチェック
  - income / expense 両方でストリーク再計算を実行
- [x] `AchievementService` に `within_current_month_budget?` / `calculate_consecutive_budget_months` を追加

### テスト
- [x] `User#current_streak` / `longest_streak` のモデルスペックを追加（date カラム参照・二重カウントなし）
- [x] `Budget` モデルスペック追加
- [x] `BudgetsController` リクエストスペック追加（`budget_first_set` 実績連携テスト含む）
- [x] `SavingsGoalsController` スペックに `goal_first_achieved` / `emergency_fund_created` テスト追加
- [x] `TransactionsController` スペックに `investment_debut` / 予算実績テスト追加

## 修正された問題

- fix #203

<!-- I want to review in Japanese. -->