### PR TITLE
feat: 実績解除タイムラインの実装

### DIFF
--- a/back/app/controllers/api/v1/achievements_controller.rb
+++ b/back/app/controllers/api/v1/achievements_controller.rb
@@ -90,7 +90,7 @@ module Api
             render json: { errors: achievement.errors.full_messages }, status: :unprocessable_content
           end
         else
-          render json: { error: 'Achievement not found' }, status: :not_found
+          render json: { error: '実績が見つかりません' }, status: :not_found
         end
       end
 

--- a/front/src/app/collection/page.tsx
+++ b/front/src/app/collection/page.tsx
@@ -22,6 +22,8 @@ const categoryLabels: Record<string, string> = {
   history: '解除履歴',
 };
 
+const ACHIEVEMENT_CATEGORIES = ["all", "savings", "streak", "expense", "special", "history"] as const;
+
 const formatUnlockedAt = (dateStr: string): string => {
   return new Intl.DateTimeFormat('ja-JP', {
     year: 'numeric',
@@ -69,12 +71,6 @@ export default function CollectionPage() {
     [achievements]
   );
 
-  // 表示するカテゴリを動的に生成（履歴タブを末尾に固定追加）
-  const achievementCategories = useMemo(
-    () => ["all", ...new Set(achievements.map((ach) => ach.category)), "history"],
-    [achievements]
-  );
-
   return (
     <div className="container mx-auto p-4 md:p-6 lg:p-8 bg-background text-foreground">
       <h1 className="text-3xl font-bold mb-8 text-foreground">コレクション</h1>
@@ -112,12 +108,10 @@ export default function CollectionPage() {
         </div>
         <Tabs value={activeTab} onValueChange={filterAchievements} className="mb-6">
           <TabsList className="bg-muted">
-            {achievementCategories.map((cat) => (
-              cat && (
-                <TabsTrigger key={cat} value={cat} className="capitalize px-4 py-2 data-[state=active]:bg-background data-[state=active]:text-foreground">
-                  {categoryLabels[cat] || cat}
-                </TabsTrigger>
-              )
+            {ACHIEVEMENT_CATEGORIES.map((cat) => (
+              <TabsTrigger key={cat} value={cat} className="capitalize px-4 py-2 data-[state=active]:bg-background data-[state=active]:text-foreground">
+                {categoryLabels[cat] || cat}
+              </TabsTrigger>
             ))}
           </TabsList>
         </Tabs>

--- a/front/src/hooks/useAchievements.ts
+++ b/front/src/hooks/useAchievements.ts
@@ -57,7 +57,9 @@ export function useAchievements(): UseAchievementsReturn {
   const filterAchievements = useCallback(
     (category: string) => {
       setActiveTab(category)
-      if (category === 'all' || category === 'history') {
+      if (category === 'history') {
+        setFilteredAchievements([])
+      } else if (category === 'all') {
         setFilteredAchievements(achievements)
       } else {
         setFilteredAchievements(


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要
コレクションページに実績解除の履歴タブを追加し、達成の記録を時系列で振り返られるようにしました。また、実績トリガーの拡充（ストリーク・予算管理・貯金マイルストーン・コミュニティ実績）も合わせて実装しています。

## 詳細な変更点
- [x] コレクションページに「解除履歴」タブを追加（all/savings/streak/expense/special に並列）
- [x] 解除済み実績を `unlocked_at` の降順で一覧表示
- [x] 各行に解除日時・実績タイトル・ティアバッジを表示
- [x] 未解除実績がない場合の空状態UI（Historyアイコン + メッセージ）を追加
- [x] カテゴリタブを定数（`ACHIEVEMENT_CATEGORIES`）で管理し、ローディング中のちらつきを防止
- [x] `filterAchievements` でヒストリータブ選択時に `filteredAchievements` を空配列にセット（意図を明示）
- [x] バックエンドのエラーメッセージを日本語に統一
- [x] ストリーク・予算管理・特別実績の自動トリガーを `AchievementService` に実装
- [x] 貯金マイルストーンとコミュニティ実績を追加

## 修正された問題

- fix #201

## レビューに関して
レビューする際には、以下のprefix(接頭辞)を付けましょう。
<!-- for GitHub Copilot review rule -->
[must] → かならず変更してね  
[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)  
[nits] → ささいな指摘(nitpick) 
[ask] → 質問  
[fyi] → 参考情報
<!-- for GitHub Copilot review rule-->
## PRのルール
- まずはDraftでPRを作成する。
- レビューに出せる状態になったらOpenにする。
- レビューなしでのmainブランチへのマージは原則禁止
<!-- I want to review in Japanese. -->