### PR TITLE
feat: 実績解除時の通知・お祝い演出を実装する

### DIFF
--- a/back/app/controllers/api/v1/transactions_controller.rb
+++ b/back/app/controllers/api/v1/transactions_controller.rb
@@ -35,8 +35,8 @@ module Api
         @transaction = current_api_v1_user.transactions.new(transaction_params)
 
         if @transaction.save
-          update_achievements_for_transaction(@transaction)
-          render json: @transaction, status: :created
+          newly_unlocked = with_achievement_tracking { update_achievements_for_transaction(@transaction) }
+          render json: { transaction: @transaction, newly_unlocked_achievements: newly_unlocked }, status: :created
         else
           render json: { errors: @transaction.errors.full_messages }, status: :unprocessable_content
         end
@@ -44,8 +44,8 @@ module Api
 
       def update
         if @transaction.update(transaction_params)
-          update_achievements_for_transaction(@transaction)
-          render json: @transaction
+          newly_unlocked = with_achievement_tracking { update_achievements_for_transaction(@transaction) }
+          render json: { transaction: @transaction, newly_unlocked_achievements: newly_unlocked }
         else
           render json: { errors: @transaction.errors.full_messages }, status: :unprocessable_content
         end
@@ -119,6 +119,30 @@ module Api
         consecutive = service.calculate_consecutive_budget_months(budgets_by_month)
 
         { budget_set: true, within_budget: within, consecutive_months: consecutive }
+      end
+
+      # 実績更新前後を比較し、新たに解除された実績を返す
+      def with_achievement_tracking
+        previously_unlocked_ids = current_api_v1_user.achievements.where(unlocked: true).pluck(:id)
+        yield
+        current_api_v1_user.achievements
+                           .where(unlocked: true)
+                           .where.not(id: previously_unlocked_ids)
+                           .map { |a| achievement_json(a) }
+      rescue StandardError
+        []
+      end
+
+      def achievement_json(achievement)
+        {
+          id: achievement.id,
+          title: achievement.title,
+          description: achievement.description,
+          tier: achievement.tier,
+          category: achievement.category,
+          reward: achievement.reward,
+          image_url: achievement.image_url
+        }
       end
     end
   end

--- a/front/src/app/dashboard/page.tsx
+++ b/front/src/app/dashboard/page.tsx
@@ -2,7 +2,7 @@
 
 import type React from "react"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -71,6 +71,9 @@ import { useRouter } from "next/navigation"
 import { useAuth } from "@/hooks/useAuth"
 import { api } from "@/lib/api"
 import { type Transaction, mapApiTransaction } from "@/types/transaction"
+import { AchievementUnlockModal } from "@/components/achievement-unlock-modal"
+import type { ApiNewlyUnlockedAchievement } from "@/types/achievement"
+import { toast } from "sonner"
 
 const EXPENSE_CATEGORIES = [
   { value: "food", label: "食費", icon: <Coffee className="h-4 w-4" /> },
@@ -105,8 +108,15 @@ export default function DashboardPage() {
   const [currentDate, setCurrentDate] = useState<Date>(new Date())
   const [otterMood, setOtterMood] = useState<"happy" | "neutral" | "sad">("neutral")
   const [isDataLoading, setIsDataLoading] = useState(false)
+  const [achievementQueue, setAchievementQueue] = useState<ApiNewlyUnlockedAchievement[]>([])
   const router = useRouter()
   const { user, token, isLoading: authIsLoading, isAuthenticated } = useAuth()
+
+  const currentAchievement = achievementQueue[0] ?? null
+
+  const handleAchievementClose = useCallback(() => {
+    setAchievementQueue((prev) => prev.slice(1))
+  }, [])
 
   useEffect(() => {
     if (!authIsLoading && !isAuthenticated) {
@@ -189,15 +199,22 @@ export default function DashboardPage() {
     const numericAmount = Number.parseFloat(amount.replace(/,/g, ""))
 
     try {
-      const newTx = await api.transactions.create(token, {
+      const result = await api.transactions.create(token, {
         amount: numericAmount,
         transaction_type: type,
         category,
         description,
         date: format(date, "yyyy-MM-dd"),
       })
-      if (newTx) {
-        setTransactions((prev) => [...prev, mapApiTransaction(newTx)])
+      if (result) {
+        setTransactions((prev) => [...prev, mapApiTransaction(result.transaction)])
+
+        if (result.newly_unlocked_achievements.length > 0) {
+          result.newly_unlocked_achievements.forEach((ach) => {
+            toast.success(`実績解除: ${ach.title}`, { description: ach.description })
+          })
+          setAchievementQueue((prev) => [...prev, ...result.newly_unlocked_achievements])
+        }
       }
       setAmount("")
       setAmountError(null)
@@ -324,6 +341,7 @@ export default function DashboardPage() {
 
   return (
     <div className="p-4 md:p-6 lg:p-8 space-y-8">
+      <AchievementUnlockModal achievement={currentAchievement} onClose={handleAchievementClose} />
       <Tutorial />
 
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">

--- a/front/src/components/achievement-unlock-modal.tsx
+++ b/front/src/components/achievement-unlock-modal.tsx
@@ -1,0 +1,124 @@
+"use client"
+
+import { useEffect } from "react"
+import { Dialog, DialogContent } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import type { AchievementTier, ApiNewlyUnlockedAchievement } from "@/types/achievement"
+import { Trophy, Star, Gem } from "lucide-react"
+
+interface AchievementUnlockModalProps {
+  achievement: ApiNewlyUnlockedAchievement | null
+  onClose: () => void
+}
+
+const TIER_CONFIG: Record<AchievementTier, { label: string; bg: string; text: string; border: string; ring: string }> = {
+  bronze: {
+    label: "ブロンズ",
+    bg: "bg-amber-100 dark:bg-amber-900/30",
+    text: "text-amber-700 dark:text-amber-400",
+    border: "border-amber-400",
+    ring: "ring-amber-300",
+  },
+  silver: {
+    label: "シルバー",
+    bg: "bg-slate-100 dark:bg-slate-800/50",
+    text: "text-slate-600 dark:text-slate-300",
+    border: "border-slate-400",
+    ring: "ring-slate-300",
+  },
+  gold: {
+    label: "ゴールド",
+    bg: "bg-yellow-100 dark:bg-yellow-900/30",
+    text: "text-yellow-700 dark:text-yellow-400",
+    border: "border-yellow-400",
+    ring: "ring-yellow-300",
+  },
+  platinum: {
+    label: "プラチナ",
+    bg: "bg-purple-100 dark:bg-purple-900/30",
+    text: "text-purple-700 dark:text-purple-400",
+    border: "border-purple-400",
+    ring: "ring-purple-300",
+  },
+}
+
+function TierIcon({ tier }: { tier: AchievementTier }) {
+  if (tier === "platinum") return <Gem className="h-12 w-12" />
+  if (tier === "gold") return <Trophy className="h-12 w-12" />
+  return <Star className="h-12 w-12" />
+}
+
+export function AchievementUnlockModal({ achievement, onClose }: AchievementUnlockModalProps) {
+  const tier = achievement?.tier ?? "bronze"
+  const config = TIER_CONFIG[tier]
+
+  useEffect(() => {
+    if (!achievement) return
+    const timer = setTimeout(onClose, 6000)
+    return () => clearTimeout(timer)
+  }, [achievement, onClose])
+
+  return (
+    <Dialog open={!!achievement} onOpenChange={(open) => { if (!open) onClose() }}>
+      <DialogContent className="max-w-sm text-center p-0 overflow-hidden border-0 bg-transparent shadow-none">
+        <div
+          className={cn(
+            "rounded-2xl border-2 p-8 space-y-4",
+            "animate-in fade-in zoom-in-95 duration-300",
+            config.bg,
+            config.border,
+          )}
+        >
+          <p className="text-xs font-semibold tracking-widest uppercase text-muted-foreground">
+            実績解除！
+          </p>
+
+          <div
+            className={cn(
+              "mx-auto w-24 h-24 rounded-full flex items-center justify-center",
+              "ring-4",
+              config.ring,
+              config.bg,
+              config.text,
+            )}
+          >
+            <TierIcon tier={tier} />
+          </div>
+
+          <div className="space-y-1">
+            <h2 className={cn("text-2xl font-bold", config.text)}>{achievement?.title}</h2>
+            <p className="text-sm text-muted-foreground">{achievement?.description}</p>
+          </div>
+
+          <div
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium",
+              config.text,
+              "border",
+              config.border,
+            )}
+          >
+            <Trophy className="h-3 w-3" />
+            {config.label}
+          </div>
+
+          {achievement?.reward && (
+            <p className="text-sm text-muted-foreground">
+              獲得報酬: <span className="font-medium">{achievement.reward}</span>
+            </p>
+          )}
+
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onClose}
+            className={cn("w-full mt-2", config.text)}
+          >
+            閉じる
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/front/src/lib/api.ts
+++ b/front/src/lib/api.ts
@@ -1,7 +1,7 @@
 import { apiRequest, publicApiRequest } from '@/lib/api-client'
 import type { ApiTransaction } from '@/types/transaction'
 import type { ApiPost, ApiComment, ApiPostsResponse } from '@/types/post'
-import type { AchievementResponse } from '@/types/achievement'
+import type { AchievementResponse, ApiNewlyUnlockedAchievement } from '@/types/achievement'
 import type { User } from '@/types/user'
 
 // ========== 型定義 ==========
@@ -115,7 +115,7 @@ export const api = {
 
     /** 取引を作成する */
     create: (token: string, params: CreateTransactionParams) =>
-      apiRequest<ApiTransaction>('/transactions', {
+      apiRequest<{ transaction: ApiTransaction; newly_unlocked_achievements: ApiNewlyUnlockedAchievement[] }>('/transactions', {
         method: 'POST',
         token,
         body: { transaction: params },

--- a/front/src/types/achievement.ts
+++ b/front/src/types/achievement.ts
@@ -2,6 +2,17 @@ export type AchievementCategory = 'savings' | 'streak' | 'expense' | 'special'
 
 export type AchievementTier = 'bronze' | 'silver' | 'gold' | 'platinum'
 
+// 取引登録・更新レスポンスに含まれる新規解除実績
+export interface ApiNewlyUnlockedAchievement {
+  id: number
+  title: string
+  description: string
+  tier: AchievementTier
+  category: AchievementCategory
+  reward: string
+  image_url: string | null
+}
+
 // ========== API 型（スネークケース） ==========
 
 export interface ApiAchievement {


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要

取引登録・更新時に新規解除された実績をリアルタイムで祝うフィードバックを実装。

## 詳細な変更点

### バックエンド
- [x] `TransactionsController` の `create`/`update` レスポンスに `newly_unlocked_achievements` を追加
  - 実績更新前後の `unlocked: true` ID を比較し、新たに解除された実績のみを返す
  - `with_achievement_tracking` ヘルパーメソッドで before/after 差分を管理
  - 実績追跡の失敗が取引登録の成功を妨げないよう `rescue StandardError => []` で保護

### フロントエンド
- [x] `ApiNewlyUnlockedAchievement` 型を `achievement.ts` に追加
- [x] `api.transactions.create` の戻り型を `{ transaction, newly_unlocked_achievements }` に更新
- [x] `achievement-unlock-modal.tsx` を新規作成
  - Tier（bronze/silver/gold/platinum）ごとのカラーテーマとアイコン
  - 6秒後に自動クローズ（手動クローズも可）
  - `useCallback` で `onClose` をメモ化しタイマーが誤リセットされないよう対処
- [x] `dashboard/page.tsx` に実績解除処理を追加
  - 新規解除実績がある場合は `sonner` toast で通知
  - 複数実績同時解除に対応するキュー管理

## 修正された問題

fix #200

<!-- I want to review in Japanese. -->