### PR TITLE
feat: 実績解除時の通知・お祝い演出を実装する

### DIFF
--- a/back/spec/requests/api/v1/transactions_spec.rb
+++ b/back/spec/requests/api/v1/transactions_spec.rb
@@ -65,6 +65,13 @@ RSpec.describe 'Api::V1::Transactions', type: :request do
       expect(response).to have_http_status(:created)
     end
 
+    it 'レスポンスに transaction と newly_unlocked_achievements が含まれる' do
+      post '/api/v1/transactions', params: valid_params, headers: headers
+      json = response.parsed_body
+      expect(json).to include('transaction', 'newly_unlocked_achievements')
+      expect(json['newly_unlocked_achievements']).to be_an(Array)
+    end
+
     it '不正なパラメータではエラーを返す' do
       post '/api/v1/transactions', params: { transaction: { amount: nil } }, headers: headers
       expect(response).to have_http_status(:unprocessable_entity)
@@ -80,6 +87,28 @@ RSpec.describe 'Api::V1::Transactions', type: :request do
         expect(response).to have_http_status(:created)
         first_savings = user.achievements.find_by(original_achievement_id: 'first_savings')
         expect(first_savings.reload.unlocked).to be true
+      end
+
+      it '実績が解除されるとレスポンスの newly_unlocked_achievements に含まれる' do
+        post '/api/v1/transactions',
+             params: { transaction: { amount: 5000, transaction_type: 'income', description: '給料', category: '給与',
+                                      date: Date.current } },
+             headers: headers
+
+        json = response.parsed_body
+        unlocked = json['newly_unlocked_achievements']
+        expect(unlocked).not_to be_empty
+        expect(unlocked.first).to include('id', 'title', 'description', 'tier', 'category', 'reward')
+      end
+
+      it '実績が解除されない場合は newly_unlocked_achievements が空配列になる' do
+        post '/api/v1/transactions',
+             params: { transaction: { amount: 1000, transaction_type: 'expense', description: '食費', category: '食費',
+                                      date: Date.current } },
+             headers: headers
+
+        json = response.parsed_body
+        expect(json['newly_unlocked_achievements']).to eq([])
       end
 
       it '収入取引を作成するとマイルストーン実績の進捗が更新される' do
@@ -164,6 +193,27 @@ RSpec.describe 'Api::V1::Transactions', type: :request do
       expect(response).to have_http_status(:ok)
       milestone = user.achievements.find_by(original_achievement_id: 'savings_milestone_30000')
       expect(milestone.reload.unlocked).to be true
+    end
+
+    it 'レスポンスに transaction と newly_unlocked_achievements が含まれる' do
+      patch "/api/v1/transactions/#{income_transaction.id}",
+            params: { transaction: { amount: 30_000 } },
+            headers: headers
+
+      json = response.parsed_body
+      expect(json).to include('transaction', 'newly_unlocked_achievements')
+      expect(json['newly_unlocked_achievements']).to be_an(Array)
+    end
+
+    it '更新で実績が解除されるとレスポンスの newly_unlocked_achievements に含まれる' do
+      patch "/api/v1/transactions/#{income_transaction.id}",
+            params: { transaction: { amount: 30_000 } },
+            headers: headers
+
+      json = response.parsed_body
+      unlocked = json['newly_unlocked_achievements']
+      expect(unlocked).not_to be_empty
+      expect(unlocked.first).to include('id', 'title', 'description', 'tier', 'category', 'reward')
     end
   end
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要

取引登録・更新時に実績が解除されたことをリアルタイムでユーザーに伝えるフィードバック機能を実装しました。バックエンドから解除された実績情報を返し、フロントエンドで toast 通知とアニメーション付きモーダルで祝福します。

## 詳細な変更点

- [x] `TransactionsController` の `create` / `update` レスポンスに `newly_unlocked_achievements` を追加（今回の操作で新規解除された実績のリスト）
- [x] `with_achievement_tracking` ヘルパーで解除前後の実績 ID を比較し、新規解除分のみ抽出
- [x] `useAchievements` フックを有効化・拡張（`refetch` を公開）
- [x] ダッシュボードで取引作成後に `newly_unlocked_achievements` を受け取り、`sonner` toast で通知
- [x] 実績解除時に `AchievementUnlockModal` を表示（ティアごとのカラーリング・アニメーション・6秒自動クローズ）
- [x] `newly_unlocked_achievements` レスポンスフィールドの RSpec テストを追加（作成・更新の両エンドポイントをカバー）

## 修正された問題

- fix #200

## レビューに関して
レビューする際には、以下のprefix(接頭辞)を付けましょう。
<!-- for GitHub Copilot review rule -->
[must] → かならず変更してね  
[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)  
[nits] → ささいな指摘(nitpick) 
[ask] → 質問  
[fyi] → 参考情報
<!-- for GitHub Copilot review rule-->
## PRのルール
- まずはDraftでPRを作成する。
- レビューに出せる状態になったらOpenにする。
- レビューなしでのmainブランチへのマージは原則禁止
<!-- I want to review in Japanese. -->