### PR TITLE
feat: コレクションページ・ダッシュボードへのカワウソ表示追加

### DIFF
--- a/front/src/app/collection/page.tsx
+++ b/front/src/app/collection/page.tsx
@@ -11,6 +11,7 @@ import { cn } from "@/lib/utils"
 import { LockIcon, UnlockIcon, AlertTriangle, Trophy, Clock, History } from 'lucide-react';
 import { useAuth } from "@/hooks/useAuth"
 import { useAchievements } from "@/hooks/useAchievements"
+import OtterAnimation from "@/components/otter-animation"
 
 // カテゴリ表示用の日本語マッピング
 const categoryLabels: Record<string, string> = {
@@ -62,6 +63,23 @@ export default function CollectionPage() {
     }
   }, [authIsLoading, isAuthenticated, router])
 
+  // 実績達成率に応じたカワウソのムードとメッセージを計算
+  const otterMood = useMemo((): "happy" | "neutral" | "sad" => {
+    if (!achievementSummary || achievementSummary.totalAchievements === 0) return "neutral"
+    const rate = achievementSummary.unlockedAchievements / achievementSummary.totalAchievements
+    if (rate >= 0.7) return "happy"
+    if (rate >= 0.3) return "neutral"
+    return "sad"
+  }, [achievementSummary])
+
+  const otterMessage = useMemo((): string => {
+    if (!achievementSummary || achievementSummary.totalAchievements === 0) return "実績を解除してカワウソを喜ばせよう！"
+    const rate = achievementSummary.unlockedAchievements / achievementSummary.totalAchievements
+    if (rate >= 0.7) return `すごい！実績の${Math.round(rate * 100)}%を達成したよ！このまま全制覇を目指そう！`
+    if (rate >= 0.3) return `実績の${Math.round(rate * 100)}%を達成中！もっと頑張ろう！`
+    return "まだ実績が少ないね...取引を記録して実績を解除しよう！"
+  }, [achievementSummary])
+
   // 解除済み実績を unlocked_at 降順で並べた履歴リスト
   const historyAchievements = useMemo(
     () =>
@@ -75,28 +93,42 @@ export default function CollectionPage() {
     <div className="container mx-auto p-4 md:p-6 lg:p-8 bg-background text-foreground">
       <h1 className="text-3xl font-bold mb-8 text-foreground">コレクション</h1>
 
-      {/* 実績サマリー表示 */}
-      {achievementSummary && !isLoading && !error && (
-        <section className="mb-8 p-4 bg-card text-card-foreground rounded-lg border">
-          <h3 className="text-xl font-semibold mb-3 text-card-foreground">実績サマリー</h3>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-center">
-            <div>
-              <p className="text-2xl font-bold text-primary">{achievementSummary.totalAchievements}</p>
-              <p className="text-sm text-muted-foreground">総実績数</p>
-            </div>
-            <div>
-              <p className="text-2xl font-bold text-green-600 dark:text-green-400">{achievementSummary.unlockedAchievements}</p>
-              <p className="text-sm text-muted-foreground">達成済み</p>
-            </div>
-            {Object.entries(achievementSummary.progressByCategory).map(([category, summary]) => (
-              summary && summary.total > 0 && (
-                <div key={category}>
-                  <p className="text-2xl font-bold text-accent-foreground">{summary.progressPercentage}%</p>
-                  <p className="text-sm text-muted-foreground capitalize">{categoryLabels[category] ?? category} 達成率</p>
+      {/* カワウソ + 実績サマリー */}
+      {!isLoading && !error && (
+        <section className="mb-8 grid grid-cols-1 md:grid-cols-4 gap-6">
+          <Card className="md:col-span-1">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-base">カワウソの様子</CardTitle>
+              <CardDescription>実績達成率に応じて変化</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <OtterAnimation mood={otterMood} customMessage={otterMessage} />
+            </CardContent>
+          </Card>
+
+          {achievementSummary && (
+            <div className="md:col-span-3 p-4 bg-card text-card-foreground rounded-lg border flex flex-col justify-center">
+              <h3 className="text-xl font-semibold mb-3 text-card-foreground">実績サマリー</h3>
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-center">
+                <div>
+                  <p className="text-2xl font-bold text-primary">{achievementSummary.totalAchievements}</p>
+                  <p className="text-sm text-muted-foreground">総実績数</p>
                 </div>
-              )
-            ))}
-          </div>
+                <div>
+                  <p className="text-2xl font-bold text-green-600 dark:text-green-400">{achievementSummary.unlockedAchievements}</p>
+                  <p className="text-sm text-muted-foreground">達成済み</p>
+                </div>
+                {Object.entries(achievementSummary.progressByCategory).map(([category, summary]) => (
+                  summary && summary.total > 0 && (
+                    <div key={category}>
+                      <p className="text-2xl font-bold text-accent-foreground">{summary.progressPercentage}%</p>
+                      <p className="text-sm text-muted-foreground capitalize">{categoryLabels[category] ?? category} 達成率</p>
+                    </div>
+                  )
+                ))}
+              </div>
+            </div>
+          )}
         </section>
       )}
 

--- a/front/src/app/dashboard/page.tsx
+++ b/front/src/app/dashboard/page.tsx
@@ -2,7 +2,7 @@
 
 import type React from "react"
 
-import { useState, useEffect, useCallback } from "react"
+import { useState, useEffect, useCallback, useMemo } from "react"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -33,6 +33,7 @@ import {
   TrendingUp,
   DollarSign,
   Loader2,
+  Trophy,
 } from "lucide-react"
 import dynamic from "next/dynamic"
 import OtterAnimation from "@/components/otter-animation"
@@ -73,6 +74,8 @@ import { api } from "@/lib/api"
 import { type Transaction, mapApiTransaction } from "@/types/transaction"
 import { AchievementUnlockModal } from "@/components/achievement-unlock-modal"
 import type { ApiNewlyUnlockedAchievement } from "@/types/achievement"
+import { Badge } from "@/components/ui/badge"
+import { useAchievements } from "@/hooks/useAchievements"
 import { toast } from "sonner"
 
 const EXPENSE_CATEGORIES = [
@@ -111,12 +114,22 @@ export default function DashboardPage() {
   const [achievementQueue, setAchievementQueue] = useState<ApiNewlyUnlockedAchievement[]>([])
   const router = useRouter()
   const { user, token, isLoading: authIsLoading, isAuthenticated } = useAuth()
+  const { achievements } = useAchievements()
 
   const currentAchievement = achievementQueue[0] ?? null
 
   const handleAchievementClose = useCallback(() => {
     setAchievementQueue((prev) => prev.slice(1))
   }, [])
+
+  const recentAchievements = useMemo(
+    () =>
+      [...achievements]
+        .filter((a) => a.unlocked && a.unlockedAt)
+        .sort((a, b) => new Date(b.unlockedAt!).getTime() - new Date(a.unlockedAt!).getTime())
+        .slice(0, 3),
+    [achievements]
+  )
 
   useEffect(() => {
     if (!authIsLoading && !isAuthenticated) {
@@ -631,6 +644,41 @@ export default function DashboardPage() {
           </CardContent>
         </Card>
       </div>
+
+      {/* 最近解除した実績バッジ */}
+      {recentAchievements.length > 0 && (
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="flex items-center gap-2">
+              <Trophy className="h-5 w-5 text-yellow-500" />
+              最近解除した実績
+            </CardTitle>
+            <CardDescription>直近で達成した実績（最大3件）</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-wrap gap-3">
+              {recentAchievements.map((ach) => (
+                <div
+                  key={ach.id}
+                  className="flex items-center gap-2 rounded-lg border bg-card px-4 py-2 shadow-sm"
+                >
+                  <Trophy className="h-4 w-4 shrink-0 text-yellow-500" />
+                  <div>
+                    <p className="text-sm font-medium leading-none">{ach.title}</p>
+                    <p className="mt-1 text-xs text-muted-foreground">{ach.description}</p>
+                  </div>
+                  <Badge variant="secondary" className="ml-2 shrink-0 text-xs">
+                    {ach.tier === "platinum" ? "プラチナ"
+                      : ach.tier === "gold" ? "ゴールド"
+                      : ach.tier === "silver" ? "シルバー"
+                      : "ブロンズ"}
+                  </Badge>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <Card>

--- a/front/src/components/otter-animation.tsx
+++ b/front/src/components/otter-animation.tsx
@@ -6,34 +6,37 @@ import { cn } from "@/lib/utils"
 
 type OtterAnimationProps = {
   mood: "happy" | "neutral" | "sad"
+  customMessage?: string
 }
 
-export default function OtterAnimation({ mood }: OtterAnimationProps) {
+export default function OtterAnimation({ mood, customMessage }: OtterAnimationProps) {
   const [message, setMessage] = useState("")
   const [isAnimating, setIsAnimating] = useState(false)
 
   useEffect(() => {
-    // Set message based on mood
-    switch (mood) {
-      case "happy":
-        setMessage("お金が貯まってきたね！このまま頑張ろう！")
-        break
-      case "neutral":
-        setMessage("収支のバランスが取れているよ。もう少し節約できるといいね！")
-        break
-      case "sad":
-        setMessage("支出が多いみたい...節約を心がけよう。")
-        break
+    if (customMessage) {
+      setMessage(customMessage)
+    } else {
+      switch (mood) {
+        case "happy":
+          setMessage("お金が貯まってきたね！このまま頑張ろう！")
+          break
+        case "neutral":
+          setMessage("収支のバランスが取れているよ。もう少し節約できるといいね！")
+          break
+        case "sad":
+          setMessage("支出が多いみたい...節約を心がけよう。")
+          break
+      }
     }
 
-    // Trigger animation when mood changes
     setIsAnimating(true)
     const timer = setTimeout(() => {
       setIsAnimating(false)
     }, 1000)
 
     return () => clearTimeout(timer)
-  }, [mood])
+  }, [mood, customMessage])
 
   return (
     <div className="flex flex-col items-center w-full">


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要

コレクションページにカワウソコンポーネントを追加し、実績達成率に応じたコメントを表示します。また、ダッシュボードに最近解除した実績バッジセクションを追加してユーザーの達成感を高めます。

## 詳細な変更点

- [x] `OtterAnimation` コンポーネントに `customMessage` prop を追加（文脈に応じたメッセージをオーバーライド可能に）
- [x] コレクション（`/collection`）ページにカワウソコンポーネントを配置
  - 実績達成率 ≥70%: happy（「すごい！〇〇%を達成したよ！」）
  - 実績達成率 ≥30%: neutral（「実績の〇〇%を達成中！」）
  - 実績達成率 <30%: sad（「まだ実績が少ないね...」）
  - 実績サマリーと横並びのグリッドレイアウトで配置
- [x] ダッシュボードに「最近解除した実績バッジ」セクションを追加
  - `useAchievements` フックを利用して実績データを取得
  - `unlocked_at` 降順で最大3件を表示
  - ティア名（ブロンズ/シルバー/ゴールド/プラチナ）をバッジで表示
  - 実績が1件もない場合はセクションを非表示

## 修正された問題

- fix #199

## レビューに関して
レビューする際には、以下のprefix(接頭辞)を付けましょう。
<!-- for GitHub Copilot review rule -->
[must] → かならず変更してね  
[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)  
[nits] → ささいな指摘(nitpick) 
[ask] → 質問  
[fyi] → 参考情報
<!-- for GitHub Copilot review rule-->
## PRのルール
- まずはDraftでPRを作成する。
- レビューに出せる状態になったらOpenにする。
- レビューなしでのmainブランチへのマージは原則禁止
<!-- I want to review in Japanese. -->